### PR TITLE
feat(suppliers): add cleaning_fee and fix validation bugs

### DIFF
--- a/docs/cleaning-fee-contract.md
+++ b/docs/cleaning-fee-contract.md
@@ -1,0 +1,108 @@
+# API Contract — Cleaning Fee (actualización suppliers)
+
+> Cambio puntual sobre la implementación existente de suppliers.
+
+---
+
+## Qué cambia
+
+Se agrega el campo `cleaning_fee` a la asignación de proveedor en una reserva.
+
+---
+
+## 1. POST /api/reservations/:id/supplier
+
+Agregar `cleaning_fee` al body (opcional, default `0`):
+
+```json
+{
+  "supplier_id": 1,
+  "payout_per_night": 180.00,
+  "cleaning_fee": 120.00,
+  "payment_terms": "Within 48h after check-out"
+}
+```
+
+---
+
+## 2. PUT /api/reservations/:id/supplier
+
+También acepta `cleaning_fee` para actualizarlo:
+
+```json
+{
+  "cleaning_fee": 150.00
+}
+```
+
+---
+
+## 3. GET /api/reservations/:id/supplier — response actualizado
+
+```json
+{
+  "id": 1,
+  "reservation_id": 1,
+  "supplier": { ... },
+  "payout_per_night": 180.00,
+  "cleaning_fee": 120.00,
+  "payment_terms": "Within 48h after check-out",
+  "calculated": {
+    "total": 1380.00,
+    "paid": 1260.00,
+    "balance": 120.00,
+    "profit": 695.00
+  }
+}
+```
+
+**Fórmulas actualizadas:**
+- `total` = `nights × payout_per_night + cleaning_fee`
+- `profit` = `reservation.total_amount − total` (margen sobre el valor del deal, no sobre pagos realizados)
+
+---
+
+## 4. Vista de recibos en pagos al proveedor
+
+El response de `GET /api/reservations/:id/supplier/payments` ya incluye `receiptImages`:
+
+```json
+[
+  {
+    "id": 1,
+    "reservationSupplierId": 1,
+    "amount": 1260.00,
+    "method": "wire",
+    "date": "2026-06-09",
+    "referenceNotes": "Wire ref #WR-001",
+    "receiptImages": [
+      "https://res.cloudinary.com/dcxa0ozit/image/upload/v1/.../receipt.jpg"
+    ],
+    "createdAt": "2026-06-09T10:00:00.000Z"
+  }
+]
+```
+
+**Lógica de UI:**
+- Si `receiptImages.length > 0` → mostrar thumbnails clickeables (abrir en lightbox o nueva pestaña)
+- Si `receiptImages` está vacío → no mostrar nada o texto "Sin recibos"
+- Las URLs son de Cloudinary, se pueden usar directamente en `<img src="..." />`
+
+**No hay cambios en la API** — el campo ya venía en el response.
+
+---
+
+## 5. Cómo mostrarlo en el resumen financiero
+
+```
+Ingresos del cliente        $2,075.00   ← suma reservation_payments
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Costo proveedor (noches)    $1,260.00   ← nights × payout_per_night
+Cleaning fee                  $120.00   ← cleaning_fee  ← NUEVO
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Total a pagar supplier      $1,380.00   ← calculated.total
+Pagado                      $1,260.00   ← calculated.paid
+Balance pendiente             $120.00   ← calculated.balance
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Profit                        $695.00   ← calculated.profit
+```

--- a/docs/suppliers-frontend-contract.md
+++ b/docs/suppliers-frontend-contract.md
@@ -90,20 +90,21 @@ Si no hay proveedor asignado devuelve `404` → mostrar botón "Asignar proveedo
     "phone": "+1 305 555 0142"
   },
   "payout_per_night": 100,
+  "cleaning_fee": 120,
   "payment_terms": "Within 48h after check-out",
   "calculated": {
-    "total": 700,
+    "total": 820,
     "paid": 350,
-    "balance": 350,
-    "profit": 700
+    "balance": 470,
+    "profit": 580
   }
 }
 ```
 
-> `total` = noches × payout_per_night
+> `total` = `noches × payout_per_night + cleaning_fee`
 > `paid` = suma de pagos registrados al proveedor
 > `balance` = total − paid
-> `profit` = suma de `reservation_payments` (cliente) − `paid` (proveedor)
+> `profit` = `reservation.total_amount − total` (margen del deal, no del flujo de caja)
 
 ### `POST /api/reservations/:id/supplier` ✅ auth
 Asigna un proveedor a la reserva. Si ya tiene uno asignado devuelve `409`.
@@ -112,10 +113,11 @@ Asigna un proveedor a la reserva. Si ya tiene uno asignado devuelve `409`.
 {
   "supplier_id": 1,
   "payout_per_night": 100,
+  "cleaning_fee": 120,
   "payment_terms": "Within 48h after check-out"
 }
 ```
-`payment_terms` es opcional. Response: mismo shape que el GET. Status `201`.
+`cleaning_fee` y `payment_terms` son opcionales. `cleaning_fee` default `0`. Response: mismo shape que el GET. Status `201`.
 
 ### `PUT /api/reservations/:id/supplier` ✅ auth
 Actualizar términos. Mismo body que POST, todos opcionales. Response: mismo shape que GET. Status `200`.

--- a/migrations/scripts/017_add_cleaning_fee_to_reservation_suppliers.sql
+++ b/migrations/scripts/017_add_cleaning_fee_to_reservation_suppliers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reservation_suppliers
+    ADD COLUMN IF NOT EXISTS cleaning_fee NUMERIC(10,2) NOT NULL DEFAULT 0;

--- a/migrations/scripts/018_normalize_payment_status.sql
+++ b/migrations/scripts/018_normalize_payment_status.sql
@@ -1,0 +1,4 @@
+-- Normalize legacy 'complete' value to 'completed' in reservations.payment_status
+UPDATE reservations
+SET payment_status = 'completed'
+WHERE payment_status = 'complete';

--- a/src/controllers/reservation.ts
+++ b/src/controllers/reservation.ts
@@ -335,7 +335,7 @@ export class ReservationController {
                     
                     // Determinar el estado de pago basado en los montos
                     if (amountDue <= 0) {
-                        updateData.paymentStatus = 'complete';
+                        updateData.paymentStatus = 'completed';
                     } else if (newAmountPaid > 0) {
                         updateData.paymentStatus = 'partial';
                     } else {
@@ -639,7 +639,7 @@ export class ReservationController {
         }
         
         // Validar payment_status
-        const validPaymentStatuses = ['PAID', 'PARTIAL', 'PENDING', 'paid', 'partial', 'pending', 'complete'];
+        const validPaymentStatuses = ['PAID', 'PARTIAL', 'PENDING', 'paid', 'partial', 'pending', 'completed'];
         
         // Si no se proporciona un estado de pago, determinar basado en los montos
         if (!payment_status) {
@@ -659,7 +659,7 @@ export class ReservationController {
         
         // Normalizar el estado de pago (convertir a minúsculas para la base de datos)
         let normalizedStatus = payment_status.toLowerCase();
-        if (normalizedStatus === 'paid') normalizedStatus = 'complete';
+        if (normalizedStatus === 'paid') normalizedStatus = 'completed';
         if (normalizedStatus === 'pending') normalizedStatus = 'pending';
         if (normalizedStatus === 'partial') normalizedStatus = 'partial';
 

--- a/src/models/reservationSupplier.ts
+++ b/src/models/reservationSupplier.ts
@@ -20,14 +20,13 @@ export class ReservationSupplierModel {
                 (r.nights * rs.payout_per_night) + rs.cleaning_fee as "totalPayout",
                 COALESCE(SUM(sp.amount), 0) as "totalPaid",
                 ((r.nights * rs.payout_per_night) + rs.cleaning_fee) - COALESCE(SUM(sp.amount), 0) as "balance",
-                COALESCE(SUM(rp.amount), 0) as "totalRevenue"
+                r.total_amount as "totalRevenue"
             FROM reservation_suppliers rs
             JOIN suppliers s ON rs.supplier_id = s.id
             JOIN reservations r ON rs.reservation_id = r.id
             LEFT JOIN supplier_payments sp ON sp.reservation_supplier_id = rs.id
-            LEFT JOIN reservation_payments rp ON rp.reservation_id = r.id
             WHERE rs.reservation_id = $1
-            GROUP BY rs.id, s.id, s.name, s.company, s.email, s.phone, r.nights
+            GROUP BY rs.id, s.id, s.name, s.company, s.email, s.phone, r.nights, r.total_amount
         `, [reservationId]);
         return rows[0] || null;
     }

--- a/src/models/reservationSupplier.ts
+++ b/src/models/reservationSupplier.ts
@@ -9,6 +9,7 @@ export class ReservationSupplierModel {
                 rs.reservation_id as "reservationId",
                 rs.supplier_id as "supplierId",
                 rs.payout_per_night as "payoutPerNight",
+                rs.cleaning_fee as "cleaningFee",
                 rs.payment_terms as "paymentTerms",
                 rs.created_at as "createdAt",
                 s.id as "supplierIdRef",
@@ -16,9 +17,9 @@ export class ReservationSupplierModel {
                 s.company as "supplierCompany",
                 s.email as "supplierEmail",
                 s.phone as "supplierPhone",
-                r.nights * rs.payout_per_night as "totalPayout",
+                (r.nights * rs.payout_per_night) + rs.cleaning_fee as "totalPayout",
                 COALESCE(SUM(sp.amount), 0) as "totalPaid",
-                (r.nights * rs.payout_per_night) - COALESCE(SUM(sp.amount), 0) as "balance",
+                ((r.nights * rs.payout_per_night) + rs.cleaning_fee) - COALESCE(SUM(sp.amount), 0) as "balance",
                 COALESCE(SUM(rp.amount), 0) as "totalRevenue"
             FROM reservation_suppliers rs
             JOIN suppliers s ON rs.supplier_id = s.id
@@ -54,16 +55,17 @@ export class ReservationSupplierModel {
     static async assign(reservationId: number, data: AssignSupplierDTO): Promise<ReservationSupplier> {
         const { rows } = await db.query(`
             INSERT INTO reservation_suppliers
-                (reservation_id, supplier_id, payout_per_night, payment_terms)
-            VALUES ($1, $2, $3, $4)
+                (reservation_id, supplier_id, payout_per_night, cleaning_fee, payment_terms)
+            VALUES ($1, $2, $3, $4, $5)
             RETURNING
                 id,
                 reservation_id as "reservationId",
                 supplier_id as "supplierId",
                 payout_per_night as "payoutPerNight",
+                cleaning_fee as "cleaningFee",
                 payment_terms as "paymentTerms",
                 created_at as "createdAt"
-        `, [reservationId, data.supplier_id, data.payout_per_night, data.payment_terms ?? null]);
+        `, [reservationId, data.supplier_id, data.payout_per_night, data.cleaning_fee ?? 0, data.payment_terms ?? null]);
         return rows[0];
     }
 
@@ -74,6 +76,7 @@ export class ReservationSupplierModel {
         const colMap: Record<string, string> = {
             supplier_id: 'supplier_id',
             payout_per_night: 'payout_per_night',
+            cleaning_fee: 'cleaning_fee',
             payment_terms: 'payment_terms'
         };
 
@@ -92,6 +95,7 @@ export class ReservationSupplierModel {
                 reservation_id as "reservationId",
                 supplier_id as "supplierId",
                 payout_per_night as "payoutPerNight",
+                cleaning_fee as "cleaningFee",
                 payment_terms as "paymentTerms",
                 created_at as "createdAt"
         `, values);

--- a/src/schemas/reservationPaymentsSchema.ts
+++ b/src/schemas/reservationPaymentsSchema.ts
@@ -8,8 +8,8 @@ const dateSchema = z.union([
 ]);
 
 export const reservationPaymentSchema = z.object({
-    reservationId: z.number().positive("Reservation ID must be a positive number"),
-    amount: z.number().min(0, "Amount must be a positive number"),
+    reservationId: z.coerce.number().positive("Reservation ID must be a positive number"),
+    amount: z.coerce.number().min(0, "Amount must be a positive number"),
     paymentDate: dateSchema,
     paymentMethod: z.enum(["card", "cash", "transfer", "paypal", "zelle", "stripe", "other"]),
     paymentReference: z.string().nullable().optional(),

--- a/src/schemas/reservationSchema.ts
+++ b/src/schemas/reservationSchema.ts
@@ -32,7 +32,10 @@ export const reservationSchema = z.object({
     parkingFee: z.number().min(0, "Parking fee must be a non-negative number"),
     cancellationFee: z.number().min(0, "Cancellation fee must be a non-negative number").optional().default(0),
     status: z.enum(["pending", "confirmed", "checked_in", "checked_out", "cancelled"]),
-    paymentStatus: z.enum(["pending", "partial", "complete"]),
+    paymentStatus: z.preprocess(
+        (val) => val === 'complete' ? 'completed' : val,
+        z.enum(["pending", "partial", "completed"])
+    ),
     notes: z.string().optional(),
     initialPayment: initialPaymentSchema,
     createdAt: dateSchema.optional().default(() => {

--- a/src/schemas/suppliersSchema.ts
+++ b/src/schemas/suppliersSchema.ts
@@ -19,8 +19,8 @@ export const assignSupplierSchema = z.object({
 const supplierPaymentMethodEnum = z.enum(['cash', 'wire', 'card', 'transfer']);
 
 export const supplierPaymentSchema = z.object({
-    reservationSupplierId: z.number().int().positive(),
-    amount: z.number().positive(),
+    reservationSupplierId: z.coerce.number().int().positive(),
+    amount: z.coerce.number().positive(),
     method: supplierPaymentMethodEnum,
     date: z.string().min(1),
     referenceNotes: z.string().optional(),

--- a/src/schemas/suppliersSchema.ts
+++ b/src/schemas/suppliersSchema.ts
@@ -12,6 +12,7 @@ export const partialSupplierSchema = supplierSchema.partial();
 export const assignSupplierSchema = z.object({
     supplier_id: z.number().int().positive(),
     payout_per_night: z.number().positive(),
+    cleaning_fee: z.number().min(0).optional().default(0),
     payment_terms: z.string().optional()
 });
 

--- a/src/services/reservationPaymentsService.ts
+++ b/src/services/reservationPaymentsService.ts
@@ -16,8 +16,8 @@ export default class ReservationPaymentsService {
             if (!reservation) return;
 
             const amountDue = reservation.totalAmount - totalPaid;
-            let paymentStatus: 'pending' | 'partial' | 'complete' = 'pending';
-            if (amountDue <= 0 && totalPaid > 0) paymentStatus = 'complete';
+            let paymentStatus: 'pending' | 'partial' | 'completed' = 'pending';
+            if (amountDue <= 0 && totalPaid > 0) paymentStatus = 'completed';
             else if (totalPaid > 0 && amountDue > 0) paymentStatus = 'partial';
 
             await ReservationModel.updateReservation(reservationId, {

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -64,7 +64,7 @@ export default class ReservationService {
     }
     
     // Actualizar campos de pago
-    static async updatePaymentFields(id: number, amountPaid: number, amountDue: number, paymentStatus: 'pending' | 'partial' | 'complete'): Promise<Reservation> {
+    static async updatePaymentFields(id: number, amountPaid: number, amountDue: number, paymentStatus: 'pending' | 'partial' | 'completed'): Promise<Reservation> {
         // Verificar que la reserva existe
         const reservation = await ReservationModel.getReservationById(id);
         if (!reservation) {

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -19,6 +19,7 @@ function formatReservationSupplier(row: ReservationSupplier): ReservationSupplie
     const total = Number(row.totalPayout ?? 0);
     const paid = Number(row.totalPaid ?? 0);
     const revenue = Number(row.totalRevenue ?? 0);
+    const cleaningFee = Number(row.cleaningFee ?? 0);
     return {
         id: row.id,
         reservation_id: row.reservationId,
@@ -30,12 +31,13 @@ function formatReservationSupplier(row: ReservationSupplier): ReservationSupplie
             phone: row.supplierPhone ?? null
         },
         payout_per_night: Number(row.payoutPerNight),
+        cleaning_fee: cleaningFee,
         payment_terms: row.paymentTerms ?? null,
         calculated: {
             total,
             paid,
             balance: total - paid,
-            profit: revenue - paid
+            profit: revenue - paid - cleaningFee
         }
     };
 }

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -37,7 +37,7 @@ function formatReservationSupplier(row: ReservationSupplier): ReservationSupplie
             total,
             paid,
             balance: total - paid,
-            profit: revenue - paid - cleaningFee
+            profit: revenue - total
         }
     };
 }

--- a/src/types/reservations.ts
+++ b/src/types/reservations.ts
@@ -15,7 +15,7 @@ export interface Reservation {
     parkingFee: number;
     cancellationFee: number;
     status: 'pending' | 'confirmed' | 'checked_in' | 'checked_out' | 'cancelled';
-    paymentStatus: 'pending' | 'partial' | 'complete';
+    paymentStatus: 'pending' | 'partial' | 'completed';
     supplierStatus: 'unassigned' | 'searching' | 'confirmed';
     notes?: string;
     createdAt: string; // Cambiado de Date a string
@@ -53,7 +53,7 @@ export interface CreateReservationDTO {
     parkingFee: number;
     cancellationFee: number;
     status: 'pending' | 'confirmed' | 'checked_in' | 'checked_out' | 'cancelled';
-    paymentStatus: 'pending' | 'partial' | 'complete';
+    paymentStatus: 'pending' | 'partial' | 'completed';
     notes?: string;
     createdAt: string; // Cambiado de Date a string
 }
@@ -74,7 +74,7 @@ export interface UpdateReservationDTO {
     parkingFee?: number;
     cancellationFee?: number;
     status?: 'pending' | 'confirmed' | 'checked_in' | 'checked_out' | 'cancelled';
-    paymentStatus?: 'pending' | 'partial' | 'complete';
+    paymentStatus?: 'pending' | 'partial' | 'completed';
     notes?: string;
 }
 

--- a/src/types/suppliers.ts
+++ b/src/types/suppliers.ts
@@ -26,6 +26,7 @@ export interface ReservationSupplier {
     reservationId: number;
     supplierId: number;
     payoutPerNight: number;
+    cleaningFee: number;
     paymentTerms?: string | null;
     createdAt: Date;
     // Raw JOIN fields (internal use)
@@ -51,6 +52,7 @@ export interface ReservationSupplierResponse {
         phone?: string | null;
     };
     payout_per_night: number;
+    cleaning_fee: number;
     payment_terms?: string | null;
     calculated: {
         total: number;
@@ -63,6 +65,7 @@ export interface ReservationSupplierResponse {
 export interface AssignSupplierDTO {
     supplier_id: number;
     payout_per_night: number;
+    cleaning_fee?: number;
     payment_terms?: string;
 }
 


### PR DESCRIPTION
## Summary

- Agrega campo `cleaning_fee` a la asignación de supplier en reservas (migration 017)
- Corrige la fórmula de profit: usa `reservation.total_amount` como base de ingresos en lugar de la suma de pagos recibidos, y elimina el doble-conteo del cleaning fee
- Normaliza el enum `paymentStatus` de `'complete'` → `'completed'` en todo el codebase (types, schemas, services, controller); agrega `z.preprocess` para tolerar valores legacy desde el frontend
- Agrega `z.coerce.number()` en schemas de endpoints `multipart/form-data` para que los campos numéricos pasen validación
- Agrega migration 018 para normalizar valores `'complete'` existentes en producción

## Migraciones a correr en Render tras el merge

```
017_add_cleaning_fee_to_reservation_suppliers.sql
018_normalize_payment_status.sql
```

## Test plan

- [x] `POST /api/reservations/:id/supplier` con `cleaning_fee` incluido
- [x] `PUT /api/reservations/:id/supplier` actualizando `payout_per_night` o `cleaning_fee`
- [x] `GET /api/reservations/:id/supplier` — verificar que `profit = total_amount - total_payout`
- [x] `POST /api/reservations/:id/supplier/payments` con imagen adjunta (multipart/form-data)
- [x] `PUT /api/reservation-payments/:id` con imagen adjunta
- [x] Reservas con `paymentStatus = 'complete'` en DB — verificar que migration 018 las normaliza

🤖 Generated with [Claude Code](https://claude.com/claude-code)