### PR TITLE
security & performance: auth, rate limiting, pagination, DB indexes, bug fixes

### DIFF
--- a/migrations/scripts/020_add_supplier_fk_indexes.sql
+++ b/migrations/scripts/020_add_supplier_fk_indexes.sql
@@ -1,0 +1,9 @@
+-- Add missing FK indexes on supplier tables
+-- reservation_suppliers.supplier_id and supplier_payments.reservation_supplier_id
+-- had no indexes despite being used in JOINs and WHERE filters, causing full table scans.
+
+CREATE INDEX IF NOT EXISTS idx_reservation_suppliers_supplier_id
+    ON reservation_suppliers(supplier_id);
+
+CREATE INDEX IF NOT EXISTS idx_supplier_payments_reservation_supplier_id
+    ON supplier_payments(reservation_supplier_id);

--- a/migrations/scripts/021_add_reservation_date_expression_indexes.sql
+++ b/migrations/scripts/021_add_reservation_date_expression_indexes.sql
@@ -1,0 +1,13 @@
+-- Expression indexes for VARCHAR date columns in the reservations table.
+-- check_in_date and check_out_date are stored as VARCHAR(50) in MM-DD-YYYY HH:mm format.
+-- All queries apply a ::date cast (e.g. check_in_date::date >= $1), making the existing
+-- idx_reservations_dates index non-sargable. These indexes match the exact expression
+-- used in WHERE clauses and ORDER BY so PostgreSQL can use index scans.
+
+SET datestyle = 'ISO, MDY';
+
+CREATE INDEX IF NOT EXISTS idx_reservations_check_in_date_expr
+    ON reservations ((check_in_date::date));
+
+CREATE INDEX IF NOT EXISTS idx_reservations_check_out_date_expr
+    ON reservations ((check_out_date::date));

--- a/migrations/scripts/021_add_reservation_date_expression_indexes.sql
+++ b/migrations/scripts/021_add_reservation_date_expression_indexes.sql
@@ -1,13 +1,16 @@
 -- Expression indexes for VARCHAR date columns in the reservations table.
 -- check_in_date and check_out_date are stored as VARCHAR(50) in MM-DD-YYYY HH:mm format.
--- All queries apply a ::date cast (e.g. check_in_date::date >= $1), making the existing
--- idx_reservations_dates index non-sargable. These indexes match the exact expression
--- used in WHERE clauses and ORDER BY so PostgreSQL can use index scans.
+-- A ::date cast is STABLE (depends on datestyle), so PostgreSQL rejects it in indexes.
+-- We create an IMMUTABLE helper function using to_date() with an explicit format,
+-- then index on that function so queries using it can do index scans.
 
-SET datestyle = 'ISO, MDY';
+CREATE OR REPLACE FUNCTION mga_parse_date(d text) RETURNS date
+    LANGUAGE sql IMMUTABLE STRICT AS $$
+    SELECT to_date(substr(d, 1, 10), 'MM-DD-YYYY')
+    $$;
 
 CREATE INDEX IF NOT EXISTS idx_reservations_check_in_date_expr
-    ON reservations ((check_in_date::date));
+    ON reservations (mga_parse_date(check_in_date));
 
 CREATE INDEX IF NOT EXISTS idx_reservations_check_out_date_expr
-    ON reservations ((check_out_date::date));
+    ON reservations (mga_parse_date(check_out_date));

--- a/migrations/scripts/022_add_cascade_to_reservation_payments.sql
+++ b/migrations/scripts/022_add_cascade_to_reservation_payments.sql
@@ -1,0 +1,10 @@
+-- Add ON DELETE CASCADE to reservation_payments.reservation_id FK.
+-- This ensures that deleting a reservation also removes its payment records,
+-- enabling safe compensating deletes when reservation creation + payment fail atomically.
+
+ALTER TABLE reservation_payments
+    DROP CONSTRAINT IF EXISTS reservation_payments_reservation_id_fkey;
+
+ALTER TABLE reservation_payments
+    ADD CONSTRAINT reservation_payments_reservation_id_fkey
+        FOREIGN KEY (reservation_id) REFERENCES reservations(id) ON DELETE CASCADE;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import multer from 'multer'
 import cors from 'cors'
 import helmet from 'helmet'
 import { rateLimit } from 'express-rate-limit'
@@ -110,6 +111,13 @@ app.use('*', (req, res) => {
 
 // Manejo de errores global
 app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err instanceof multer.MulterError) {
+        const message = err.code === 'LIMIT_FILE_SIZE'
+            ? 'File too large. Maximum size is 10MB'
+            : err.message
+        res.status(400).json({ error: message })
+        return
+    }
     res.status(500).json({
         error: 'Internal server error',
         message: process.env.NODE_ENV === 'development' ? err.message : undefined

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,6 +51,22 @@ const corsOptions = {
     maxAge: 86400
 }
 
+const globalRateLimit = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    message: { error: 'Too many requests, please try again later' },
+    standardHeaders: true,
+    legacyHeaders: false,
+})
+
+const uploadRateLimit = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 30,
+    message: { error: 'Too many upload requests, please try again later' },
+    standardHeaders: true,
+    legacyHeaders: false,
+})
+
 const loginRateLimit = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutos
     limit: 10,
@@ -61,6 +77,7 @@ const loginRateLimit = rateLimit({
 
 app.use(helmet())
 app.use(cors(corsOptions))
+app.use(globalRateLimit)
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
@@ -70,10 +87,10 @@ if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
 }
 
 // Configuración de rutas
-app.use('/api/apartments', apartmentRoutes)
-app.use('/api/cars', carRoutes)
-app.use('/api/villas', villaRoutes)
-app.use('/api/yachts', yachtRoutes)
+app.use('/api/apartments', uploadRateLimit, apartmentRoutes)
+app.use('/api/cars', uploadRateLimit, carRoutes)
+app.use('/api/villas', uploadRateLimit, villaRoutes)
+app.use('/api/yachts', uploadRateLimit, yachtRoutes)
 app.use('/api/reviews', reviewRoutes)
 app.use('/api/admins', adminRoutes)
 app.use('/api/auth', loginRateLimit, authRoutes)

--- a/src/controllers/apartment.ts
+++ b/src/controllers/apartment.ts
@@ -3,6 +3,7 @@ import ApartmentModel, { ApartmentFilters } from '../models/apartment.js'
 import { validateApartment, validatePartialApartment, validateApartmentFilters } from '../schemas/apartmentSchema.js'
 import ImageService from '../services/imageService.js'
 import { Apartment, CreateApartmentDTO, UpdateApartmentDTO } from '../types/index.js'
+import { parsePagination, paginatedResponse } from '../utils/pagination.js'
 
 class ApartmentController {
     static async getAllApartments(req: Request, res: Response): Promise<void> {
@@ -37,21 +38,19 @@ class ApartmentController {
                 }
             }
 
-            const apartments = await ApartmentModel.getAll(Object.keys(filters).length ? filters : undefined)
-            
-            // Optimizar imágenes para listado (contexto 'list')
-            const optimizedApartments = apartments.map(apartment => {
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await ApartmentModel.getAll(Object.keys(filters).length ? filters : undefined, pagination ?? undefined);
+            const optimizedApartments = rows.map(apartment => {
                 if (apartment.images && Array.isArray(apartment.images)) {
-                    const optimizedImages = ImageService.optimizeForContext(apartment.images, 'list');
-                    return {
-                        ...apartment,
-                        images: optimizedImages.images // URLs optimizadas para listado
-                    };
+                    return { ...apartment, images: ImageService.optimizeForContext(apartment.images, 'list').images };
                 }
                 return apartment;
             });
-
-            res.status(200).json(optimizedApartments)
+            if (pagination) {
+                res.status(200).json(paginatedResponse(optimizedApartments, total, pagination));
+            } else {
+                res.status(200).json(optimizedApartments);
+            }
         } catch (error: any) {
             res.status(500).json({ error: error.message })
         }

--- a/src/controllers/car.ts
+++ b/src/controllers/car.ts
@@ -3,6 +3,7 @@ import CarModel from '../models/car.js'
 import { validateCar, validatePartialCar, validateCarFilters } from '../schemas/carSchema.js'
 import ImageService from '../services/imageService.js'
 import { Cars, CreateCarsDTO, UpdateCarsDTO, CarFilters } from '../types/index.js'
+import { parsePagination, paginatedResponse } from '../utils/pagination.js'
 
 class CarController {
     static async getAllCars(req: Request, res: Response): Promise<void> {
@@ -38,25 +39,23 @@ class CarController {
                 }
             }
 
-            // Obtener cars con o sin filtros
-            const cars = Object.keys(cleanFilters).length > 0 
-                ? await CarModel.getCarsWithFilters(cleanFilters)
-                : await CarModel.getAll();
+            const pagination = parsePagination(req.query);
+            const { rows, total } = Object.keys(cleanFilters).length > 0
+                ? await CarModel.getCarsWithFilters(cleanFilters, pagination ?? undefined)
+                : await CarModel.getAll(pagination ?? undefined);
 
-            // Optimizar imágenes para listado (contexto 'list')
-            const optimizedCars = cars.map(car => {
+            const optimizedCars = rows.map(car => {
                 if (car.images && Array.isArray(car.images)) {
-                    const optimizedImages = ImageService.optimizeForContext(car.images, 'list');
-                    
-                    return {
-                        ...car,
-                        images: optimizedImages.images // URLs optimizadas para listado
-                    };
+                    return { ...car, images: ImageService.optimizeForContext(car.images, 'list').images };
                 }
                 return car;
             });
-                
-            res.status(200).json(optimizedCars);
+
+            if (pagination) {
+                res.status(200).json(paginatedResponse(optimizedCars, total, pagination));
+            } else {
+                res.status(200).json(optimizedCars);
+            }
         } catch (error: any) {
             console.error('Error in getAllCars:', error);
             res.status(500).json({ error: 'An error occurred while fetching cars' });

--- a/src/controllers/reservation.ts
+++ b/src/controllers/reservation.ts
@@ -176,7 +176,7 @@ export class ReservationController {
 
                 try {
                     // Registrar el pago en la tabla reservation_payments
-                    const createdPayment = await ReservationPaymentsService.createPayment({
+                    await ReservationPaymentsService.createPayment({
                         reservationId: Number(newReservation.id),
                         amount: Number(amount),
                         paymentMethod,
@@ -190,11 +190,13 @@ export class ReservationController {
                     res.status(201).json(updatedReservation);
                     return;
                 } catch (err: any) {
+                    // Payment failed — delete the reservation to avoid orphan rows.
+                    // ON DELETE CASCADE on reservation_payments ensures any partial payment rows are also removed.
+                    await ReservationModel.deleteReservation(Number(newReservation.id)).catch(() => {});
                     res.status(400).json({
                         error: 'payment_error',
                         message: 'Error al registrar el pago',
-                        details: err?.message || 'Unknown payment error',
-                        reservationId: newReservation?.id
+                        details: err?.message || 'Unknown payment error'
                     });
                     return;
                 }

--- a/src/controllers/reservation.ts
+++ b/src/controllers/reservation.ts
@@ -7,6 +7,7 @@ import EmailService from '../services/emailService.js';
 import db from '../utils/db_render.js';
 import PdfService from '../services/pdfService.js';
 import ImageService from '../services/imageService.js';
+import { parsePagination, paginatedResponse } from '../utils/pagination.js';
 
 export class ReservationController {
     static async getAllReservations(req: Request, res: Response): Promise<void> {
@@ -111,8 +112,13 @@ export class ReservationController {
                 filters.withinDays = withinDays;
             }
             
-            const reservations = await ReservationService.getAllReservations(filters);
-            res.status(200).json(reservations);
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await ReservationService.getAllReservations(filters, pagination ?? undefined);
+            if (pagination) {
+                res.status(200).json(paginatedResponse(rows, total, pagination));
+            } else {
+                res.status(200).json(rows);
+            }
         } catch (error) {
             res.status(500).json({ error: 'Error fetching reservations' });
         }

--- a/src/controllers/reservationPayments.ts
+++ b/src/controllers/reservationPayments.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { validateReservationPayment, validatePartialReservationPayment } from '../schemas/reservationPaymentsSchema.js';
 import ReservationPaymentsService from '../services/reservationPaymentsService.js';
 import ImageService from '../services/imageService.js';
+import { parsePagination, paginatedResponse } from '../utils/pagination.js';
 
 export class ReservationPaymentController {
     static async getAllReservationPayments(req: Request, res: Response): Promise<void> {
@@ -67,8 +68,13 @@ export class ReservationPaymentController {
             //     filters.status = req.query.status as string;
             // }
             
-            const reservationPayments = await ReservationPaymentsService.getAllPayments(filters);
-            res.status(200).json(reservationPayments);
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await ReservationPaymentsService.getAllPayments(filters, pagination ?? undefined);
+            if (pagination) {
+                res.status(200).json(paginatedResponse(rows, total, pagination));
+            } else {
+                res.status(200).json(rows);
+            }
         } catch (error) {
             res.status(500).json({ error: 'Error fetching reservation payments' });
         }

--- a/src/controllers/suppliers.ts
+++ b/src/controllers/suppliers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import SupplierService from '../services/supplierService.js';
+import { parsePagination, paginatedResponse } from '../utils/pagination.js';
 import {
     validateSupplier,
     validatePartialSupplier,
@@ -13,8 +14,13 @@ import {
 export class SupplierController {
     static async getAll(req: Request, res: Response): Promise<void> {
         try {
-            const suppliers = await SupplierService.getAllSuppliers();
-            res.status(200).json(suppliers);
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await SupplierService.getAllSuppliers(pagination ?? undefined);
+            if (pagination) {
+                res.status(200).json(paginatedResponse(rows, total, pagination));
+            } else {
+                res.status(200).json(rows);
+            }
         } catch (error: any) {
             res.status(500).json({ error: error.message });
         }

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -3,6 +3,7 @@ import UserModel from '../models/user.js'
 import { validateUser, validateUserFilters } from '../schemas/userSchema.js'
 import { Client } from '../types/index.js'
 import type { UserFilters } from '../schemas/userSchema.js'
+import { parsePagination, paginatedResponse } from '../utils/pagination.js'
 
 interface CreateUserData {
   name: string;
@@ -44,8 +45,13 @@ class UserController {
                 }
             }
 
-            const users = await UserModel.getAll(Object.keys(filters).length ? filters : undefined)
-            res.status(200).json(users)
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await UserModel.getAll(Object.keys(filters).length ? filters : undefined, pagination ?? undefined);
+            if (pagination) {
+                res.status(200).json(paginatedResponse(rows, total, pagination));
+            } else {
+                res.status(200).json(rows);
+            }
         } catch (error: any) {
             res.status(500).json({ error: error.message })
         }

--- a/src/controllers/villa.ts
+++ b/src/controllers/villa.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import VillaModel from '../models/villa.js'
-import { validateVilla } from '../schemas/villaSchema.js'
+import { validateVilla, validatePartialVilla } from '../schemas/villaSchema.js'
 import ImageService from '../services/imageService.js'
 import { CreateVillaDTO } from '../types/index.js'
 
@@ -128,22 +128,12 @@ class VillaController {
                 return;
             }
 
-            const villaData = req.body;
-
-            // Validación de numeros
-            if (
-                (villaData.capacity !== undefined && isNaN(Number(villaData.capacity))) ||
-                (villaData.bathrooms !== undefined && isNaN(Number(villaData.bathrooms))) ||
-                (villaData.rooms !== undefined && isNaN(Number(villaData.rooms)))
-            ) {
-                res.status(400).json({ message: 'Invalid capacity value' });
+            const validationResult = validatePartialVilla(req.body);
+            if (!validationResult.success) {
+                res.status(400).json({ error: 'Validation failed', details: validationResult.error.format() });
                 return;
             }
-
-            if (villaData.price !== undefined && isNaN(Number(villaData.price))) {
-                res.status(400).json({ message: 'Invalid price value' });
-                return;
-            }
+            const villaData: any = { ...validationResult.data };
 
             // Procesar imágenes usando el servicio centralizado
             if (req.files) {

--- a/src/controllers/villa.ts
+++ b/src/controllers/villa.ts
@@ -3,25 +3,24 @@ import VillaModel from '../models/villa.js'
 import { validateVilla, validatePartialVilla } from '../schemas/villaSchema.js'
 import ImageService from '../services/imageService.js'
 import { CreateVillaDTO } from '../types/index.js'
+import { parsePagination, paginatedResponse } from '../utils/pagination.js'
 
 class VillaController {
     static async getAllVillas(req: Request, res: Response): Promise<void> {
         try {
-            const villas = await VillaModel.getAll()
-            
-            // Optimizar imágenes para listado (contexto 'list')
-            const optimizedVillas = villas.map(villa => {
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await VillaModel.getAll(pagination ?? undefined);
+            const optimized = rows.map(villa => {
                 if (villa.images && Array.isArray(villa.images)) {
-                    const optimizedImages = ImageService.optimizeForContext(villa.images, 'list');
-                    return {
-                        ...villa,
-                        images: optimizedImages.images // URLs optimizadas para listado
-                    };
+                    return { ...villa, images: ImageService.optimizeForContext(villa.images, 'list').images };
                 }
                 return villa;
             });
-
-            res.status(200).json(optimizedVillas)
+            if (pagination) {
+                res.status(200).json(paginatedResponse(optimized, total, pagination));
+            } else {
+                res.status(200).json(optimized);
+            }
         } catch (error: any) {
             res.status(500).json({ error: error.message })
         }

--- a/src/controllers/yacht.ts
+++ b/src/controllers/yacht.ts
@@ -3,25 +3,24 @@ import YachtModel from '../models/yacht.js'
 import { validateYacht, validatePartialYacht } from '../schemas/yachtSchema.js'
 import ImageService from '../services/imageService.js'
 import { Yacht, CreateYachtDTO, UpdateYachtDTO } from '../types/index.js'
+import { parsePagination, paginatedResponse } from '../utils/pagination.js'
 
 class YachtController {
     static async getAllYachts(req: Request, res: Response): Promise<void> {
         try {
-            const yachts = await YachtModel.getAll()
-            
-            // Optimizar imágenes para listado (contexto 'list')
-            const optimizedYachts = yachts.map(yacht => {
+            const pagination = parsePagination(req.query);
+            const { rows, total } = await YachtModel.getAll(pagination ?? undefined);
+            const optimized = rows.map(yacht => {
                 if (yacht.images && Array.isArray(yacht.images)) {
-                    const optimizedImages = ImageService.optimizeForContext(yacht.images, 'list');
-                    return {
-                        ...yacht,
-                        images: optimizedImages.images // URLs optimizadas para listado
-                    };
+                    return { ...yacht, images: ImageService.optimizeForContext(yacht.images, 'list').images };
                 }
                 return yacht;
             });
-
-            res.status(200).json(optimizedYachts)
+            if (pagination) {
+                res.status(200).json(paginatedResponse(optimized, total, pagination));
+            } else {
+                res.status(200).json(optimized);
+            }
         } catch (error: any) {
             res.status(500).json({ error: error.message })
         }

--- a/src/controllers/yacht.ts
+++ b/src/controllers/yacht.ts
@@ -119,18 +119,12 @@ class YachtController {
                 return;
             }
 
-            const yachtData = req.body;
-
-            // Validación de números
-            if (yachtData.capacity !== undefined && isNaN(Number(yachtData.capacity))) {
-                res.status(400).json({ message: 'Invalid capacity value' });
+            const validationResult = validatePartialYacht(req.body);
+            if (!validationResult.success) {
+                res.status(400).json({ error: 'Validation failed', details: validationResult.error.format() });
                 return;
             }
-
-            if (yachtData.price !== undefined && isNaN(Number(yachtData.price))) {
-                res.status(400).json({ message: 'Invalid price value' });
-                return;
-            }
+            const yachtData: any = { ...validationResult.data };
 
             // Procesar imágenes usando el servicio centralizado
             if (req.files && Array.isArray(req.files) && req.files.length > 0) {

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -17,7 +17,7 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
             return
         }
 
-        const decoded = jwt.verify(token, JWT_SECRET) as { id: number; username: string }
+        const decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }) as { id: number; username: string }
         req.user = decoded
         
         next()

--- a/src/models/apartment.ts
+++ b/src/models/apartment.ts
@@ -129,29 +129,27 @@ export default class ApartmentModel {
 
         try {
             updatedValues.push(id)
-            const query = `UPDATE apartments SET ${updateFields.join(', ')} WHERE id = $${paramCount};`
-            await db.query(query, updatedValues)
-            
-            const { rows } = await db.query('SELECT * FROM apartments WHERE id = $1', [id])
+            const query = `UPDATE apartments SET ${updateFields.join(', ')} WHERE id = $${paramCount} RETURNING *;`
+            const { rows } = await db.query(query, updatedValues)
 
-            if (rows.length > 0) {
-                const updatedApartment = rows[0]
-                if (updatedApartment.images) {
-                    if (typeof updatedApartment.images === 'string') {
-                        try {
-                            updatedApartment.images = JSON.parse(updatedApartment.images)
-                        } catch (error) {
-                            console.error('Error parsing images:', error)
-                            updatedApartment.images = []
-                        }
-                    } else if (!Array.isArray(updatedApartment.images)) {
-                        updatedApartment.images = []
-                    }
-                }
-                return this.mapDatabaseToApartment(updatedApartment);
-            } else {
+            if (rows.length === 0) {
                 throw new Error('Apartment not found')
             }
+
+            const updatedApartment = rows[0]
+            if (updatedApartment.images) {
+                if (typeof updatedApartment.images === 'string') {
+                    try {
+                        updatedApartment.images = JSON.parse(updatedApartment.images)
+                    } catch (error) {
+                        console.error('Error parsing images:', error)
+                        updatedApartment.images = []
+                    }
+                } else if (!Array.isArray(updatedApartment.images)) {
+                    updatedApartment.images = []
+                }
+            }
+            return this.mapDatabaseToApartment(updatedApartment);
         } catch (error) {
             throw new Error('Error updating apartment')
         }

--- a/src/models/apartment.ts
+++ b/src/models/apartment.ts
@@ -1,6 +1,7 @@
 import db from '../utils/db_render.js';
 import { Apartment } from '../types/index.js';
 import { validateApartment } from '../schemas/apartmentSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export interface ApartmentFilters {
     minPrice?: number
@@ -10,9 +11,8 @@ export interface ApartmentFilters {
 }
 
 export default class ApartmentModel {
-    static async getAll(filters?: ApartmentFilters): Promise<Apartment[]> {
+    static async getAll(filters?: ApartmentFilters, pagination?: PaginationParams): Promise<{ rows: Apartment[], total: number }> {
         try {
-            // Build dynamic filtering when filters are provided
             const conditions: string[] = []
             const values: any[] = []
 
@@ -33,11 +33,17 @@ export default class ApartmentModel {
                 conditions.push(`address ILIKE $${values.length}`)
             }
 
-            const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-            const query = `SELECT * FROM apartments ${whereClause}`
+            const whereClause = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : ''
 
-            const { rows } = await db.query(query, values)
-            return rows.map(row => this.mapDatabaseToApartment(row));
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(`SELECT * FROM apartments${whereClause} ORDER BY id ASC LIMIT $${values.length + 1} OFFSET $${values.length + 2}`, [...values, pagination.limit, pagination.offset]),
+                    db.query(`SELECT COUNT(*) FROM apartments${whereClause}`, values),
+                ]);
+                return { rows: data.rows.map(row => this.mapDatabaseToApartment(row)), total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(`SELECT * FROM apartments${whereClause} ORDER BY id ASC`, values)
+            return { rows: rows.map(row => this.mapDatabaseToApartment(row)), total: rows.length };
         } catch (error) {
             throw error;
         }

--- a/src/models/car.ts
+++ b/src/models/car.ts
@@ -1,6 +1,7 @@
 import db from '../utils/db_render.js';
 import { Cars, CarFilters } from '../types/index.js';
 import { validateCar } from '../schemas/carSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export default class CarModel {
     /**
@@ -30,72 +31,66 @@ export default class CarModel {
             .filter((url: string | null): url is string => url !== null && url.trim() !== '');
     }
 
-    static async getAll(): Promise<Cars[]> {
+    private static processCarImages(rows: any[]): Cars[] {
+        return rows.map(car => {
+            if (typeof car.images === 'string') {
+                try { car.images = this.normalizeImageArray(JSON.parse(car.images)); }
+                catch { car.images = []; }
+            } else if (Array.isArray(car.images)) {
+                car.images = this.normalizeImageArray(car.images);
+            } else {
+                car.images = [];
+            }
+            return car;
+        });
+    }
+
+    static async getAll(pagination?: PaginationParams): Promise<{ rows: Cars[], total: number }> {
         try {
-            const { rows } = await db.query('SELECT * FROM cars');
-            return rows.map(car => {
-                if (typeof car.images === 'string') {
-                    try {
-                        car.images = this.normalizeImageArray(JSON.parse(car.images));
-                    } catch (error) {
-                        console.error('Error parsing car images:', error);
-                        car.images = [];
-                    }
-                } else if (Array.isArray(car.images)) {
-                    car.images = this.normalizeImageArray(car.images);
-                } else {
-                    car.images = [];
-                }
-                return car;
-            })
+            const base = 'SELECT * FROM cars ORDER BY id ASC';
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(base + ' LIMIT $1 OFFSET $2', [pagination.limit, pagination.offset]),
+                    db.query('SELECT COUNT(*) FROM cars'),
+                ]);
+                return { rows: this.processCarImages(data.rows), total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(base);
+            return { rows: this.processCarImages(rows), total: rows.length };
         } catch (error) {
-            throw error
+            throw error;
         }
     }
 
-    static async getCarsWithFilters(filters: CarFilters): Promise<Cars[]> {
+    static async getCarsWithFilters(filters: CarFilters, pagination?: PaginationParams): Promise<{ rows: Cars[], total: number }> {
         try {
-            let query = 'SELECT * FROM cars WHERE 1=1';
+            const conditions: string[] = [];
             const queryParams: any[] = [];
-            let paramCount = 1;
 
-            // Filtro por precio mínimo
             if (filters.minPrice !== undefined) {
-                query += ` AND price >= $${paramCount++}`;
                 queryParams.push(filters.minPrice);
+                conditions.push(`price >= $${queryParams.length}`);
             }
-
-            // Filtro por precio máximo
             if (filters.maxPrice !== undefined) {
-                query += ` AND price <= $${paramCount++}`;
                 queryParams.push(filters.maxPrice);
+                conditions.push(`price <= $${queryParams.length}`);
             }
-
-            // Filtro por cantidad de pasajeros
             if (filters.passengers !== undefined) {
-                query += ` AND passengers >= $${paramCount++}`;
                 queryParams.push(filters.passengers);
+                conditions.push(`passengers >= $${queryParams.length}`);
             }
 
-            query += ' ORDER BY id ASC';
+            const whereClause = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
 
-            const { rows } = await db.query(query, queryParams);
-            
-            return rows.map(car => {
-                if (typeof car.images === 'string') {
-                    try {
-                        car.images = this.normalizeImageArray(JSON.parse(car.images));
-                    } catch (error) {
-                        console.error('Error parsing car images:', error);
-                        car.images = [];
-                    }
-                } else if (Array.isArray(car.images)) {
-                    car.images = this.normalizeImageArray(car.images);
-                } else {
-                    car.images = [];
-                }
-                return car;
-            });
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(`SELECT * FROM cars${whereClause} ORDER BY id ASC LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`, [...queryParams, pagination.limit, pagination.offset]),
+                    db.query(`SELECT COUNT(*) FROM cars${whereClause}`, queryParams),
+                ]);
+                return { rows: this.processCarImages(data.rows), total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(`SELECT * FROM cars${whereClause} ORDER BY id ASC`, queryParams);
+            return { rows: this.processCarImages(rows), total: rows.length };
         } catch (error) {
             throw error;
         }

--- a/src/models/monthlySummary.ts
+++ b/src/models/monthlySummary.ts
@@ -205,8 +205,8 @@ export class MonthlySummaryModel {
                 FROM reservations r
                 LEFT JOIN clients c ON r.client_id = c.id
                 LEFT JOIN apartments a ON r.apartment_id = a.id
-                WHERE r.check_in_date::date >= make_date($2::int, $1::int, 1)
-                  AND r.check_in_date::date <  make_date($2::int, $1::int, 1) + INTERVAL '1 month'
+                WHERE mga_parse_date(r.check_in_date) >= make_date($2::int, $1::int, 1)
+                  AND mga_parse_date(r.check_in_date) <  make_date($2::int, $1::int, 1) + INTERVAL '1 month'
                 ORDER BY r.id ASC;
             `;
             

--- a/src/models/monthlySummary.ts
+++ b/src/models/monthlySummary.ts
@@ -205,16 +205,8 @@ export class MonthlySummaryModel {
                 FROM reservations r
                 LEFT JOIN clients c ON r.client_id = c.id
                 LEFT JOIN apartments a ON r.apartment_id = a.id
-                WHERE (
-                    CASE 
-                        WHEN r.check_in_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' THEN 
-                            EXTRACT(MONTH FROM r.check_in_date::date) = $1 
-                            AND EXTRACT(YEAR FROM r.check_in_date::date) = $2
-                        ELSE 
-                            EXTRACT(MONTH FROM to_date(substr(r.check_in_date, 1, 10), 'MM-DD-YYYY')) = $1
-                            AND EXTRACT(YEAR FROM to_date(substr(r.check_in_date, 1, 10), 'MM-DD-YYYY')) = $2
-                    END
-                )
+                WHERE r.check_in_date::date >= make_date($2::int, $1::int, 1)
+                  AND r.check_in_date::date <  make_date($2::int, $1::int, 1) + INTERVAL '1 month'
                 ORDER BY r.id ASC;
             `;
             

--- a/src/models/monthlySummary.ts
+++ b/src/models/monthlySummary.ts
@@ -240,8 +240,8 @@ export class MonthlySummaryModel {
                 FROM reservation_payments rp
                 JOIN reservations r ON rp.reservation_id = r.id
                 JOIN clients c ON r.client_id = c.id
-                WHERE EXTRACT(MONTH FROM rp.payment_date) = $1 
-                AND EXTRACT(YEAR FROM rp.payment_date) = $2
+                WHERE rp.payment_date >= make_date($2, $1, 1)
+                  AND rp.payment_date <  make_date($2, $1, 1) + INTERVAL '1 month'
                 ORDER BY rp.id ASC;
             `;
             

--- a/src/models/reservation.ts
+++ b/src/models/reservation.ts
@@ -57,12 +57,12 @@ export class ReservationModel {
             // Añadir filtros si existen
             if (filters.startDate) {
                 queryParams.push(filters.startDate);
-                conditions.push(`r.check_in_date::date >= $${queryParams.length}::date`);
+                conditions.push(`mga_parse_date(r.check_in_date) >= $${queryParams.length}::date`);
             }
 
             if (filters.endDate) {
                 queryParams.push(filters.endDate);
-                conditions.push(`r.check_out_date::date <= $${queryParams.length}::date`);
+                conditions.push(`mga_parse_date(r.check_out_date) <= $${queryParams.length}::date`);
             }
             
             if (filters.status) {
@@ -103,18 +103,18 @@ export class ReservationModel {
                 // Determinar la fecha base para comparación
                 if (filters.fromDate) {
                     queryParams.push(filters.fromDate);
-                    conditions.push(`r.check_in_date::date >= $${queryParams.length}::date`);
+                    conditions.push(`mga_parse_date(r.check_in_date) >= $${queryParams.length}::date`);
                 } else {
-                    conditions.push(`r.check_in_date::date >= CURRENT_DATE`);
+                    conditions.push(`mga_parse_date(r.check_in_date) >= CURRENT_DATE`);
                 }
 
                 if (filters.withinDays !== undefined) {
                     queryParams.push(filters.withinDays);
                     if (filters.fromDate) {
                         const fromDateParam = queryParams.findIndex(p => p === filters.fromDate) + 1;
-                        conditions.push(`r.check_in_date::date < $${fromDateParam}::date + ($${queryParams.length} || ' days')::interval`);
+                        conditions.push(`mga_parse_date(r.check_in_date) < $${fromDateParam}::date + ($${queryParams.length} || ' days')::interval`);
                     } else {
-                        conditions.push(`r.check_in_date::date < CURRENT_DATE + ($${queryParams.length} || ' days')::interval`);
+                        conditions.push(`mga_parse_date(r.check_in_date) < CURRENT_DATE + ($${queryParams.length} || ' days')::interval`);
                     }
                 }
             }
@@ -125,7 +125,7 @@ export class ReservationModel {
             }
             
             // Ordenar por fecha de check-in descendente (más recientes primero)
-            query += ` ORDER BY r.check_in_date::date DESC`;
+            query += ` ORDER BY mga_parse_date(r.check_in_date) DESC`;
             
             const { rows } = await db.query(query, queryParams);
             return rows;

--- a/src/models/reservation.ts
+++ b/src/models/reservation.ts
@@ -1,11 +1,12 @@
 import db from '../utils/db_render.js';
 import { Reservation } from '../types/reservations.js';
 import { validateReservation, validatePartialReservation, parseReservationDate } from '../schemas/reservationSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export class ReservationModel {
     static async getAllReservations(filters: {
-        startDate?: string, // Cambiado de Date a string
-        endDate?: string,   // Cambiado de Date a string
+        startDate?: string,
+        endDate?: string,
         status?: string,
         clientName?: string,
         clientEmail?: string,
@@ -14,7 +15,7 @@ export class ReservationModel {
         upcoming?: boolean,
         fromDate?: string,
         withinDays?: number
-    } = {}): Promise<Reservation[]> {
+    } = {}, pagination?: PaginationParams): Promise<{ rows: Reservation[], total: number }> {
         let query = `
             SELECT r.id,
                 r.apartment_id as "apartmentId",
@@ -119,16 +120,22 @@ export class ReservationModel {
                 }
             }
             
-            // Añadir condiciones a la consulta
-            if (conditions.length > 0) {
-                query += ' WHERE ' + conditions.join(' AND ');
-            }
-            
-            // Ordenar por fecha de check-in descendente (más recientes primero)
+            const whereClause = conditions.length > 0 ? ' WHERE ' + conditions.join(' AND ') : '';
+            query += whereClause;
             query += ` ORDER BY mga_parse_date(r.check_in_date) DESC`;
-            
+
+            if (pagination) {
+                const countQuery = `SELECT COUNT(*) FROM reservations r LEFT JOIN clients c ON r.client_id = c.id LEFT JOIN apartments a ON r.apartment_id = a.id${whereClause}`;
+                queryParams.push(pagination.limit, pagination.offset);
+                query += ` LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}`;
+                const [data, count] = await Promise.all([
+                    db.query(query, queryParams),
+                    db.query(countQuery, queryParams.slice(0, -2)),
+                ]);
+                return { rows: data.rows, total: parseInt(count.rows[0].count) };
+            }
             const { rows } = await db.query(query, queryParams);
-            return rows;
+            return { rows, total: rows.length };
         } catch (error) {
             console.error('Error in getAllReservations:', error);
             throw error;

--- a/src/models/reservationPayment.ts
+++ b/src/models/reservationPayment.ts
@@ -1,6 +1,7 @@
 import db from '../utils/db_render.js';
 import { ReservationPayment } from '../types/reservationPayments.js';
 import { validateReservationPayment, validatePartialReservationPayment } from '../schemas/reservationPaymentsSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export class ReservationPaymentModel {
     static async getAllReservationPayments(filters: {
@@ -13,7 +14,7 @@ export class ReservationPaymentModel {
         clientLastname?: string,
         reservationId?: number,
         status?: string
-    } = {}): Promise<ReservationPayment[]> {
+    } = {}, pagination?: PaginationParams): Promise<{ rows: ReservationPayment[], total: number }> {
         let query = `
             SELECT
                 rp.id,
@@ -92,17 +93,22 @@ export class ReservationPaymentModel {
                 conditions.push(`c.lastname ILIKE $${queryParams.length}`);
             }
             
-            // Añadir condiciones a la consulta
-            if (conditions.length > 0) {
-                query += ' WHERE ' + conditions.join(' AND ');
-            }
-            
-            // Ordenar por fecha de pago descendente
+            const whereClause = conditions.length > 0 ? ' WHERE ' + conditions.join(' AND ') : '';
+            query += whereClause;
             query += ' ORDER BY rp.payment_date DESC';
-            
+
+            if (pagination) {
+                const countQuery = `SELECT COUNT(*) FROM reservation_payments rp LEFT JOIN reservations r ON rp.reservation_id = r.id LEFT JOIN clients c ON r.client_id = c.id${whereClause}`;
+                queryParams.push(pagination.limit, pagination.offset);
+                query += ` LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}`;
+                const [data, count] = await Promise.all([
+                    db.query(query, queryParams),
+                    db.query(countQuery, queryParams.slice(0, -2)),
+                ]);
+                return { rows: data.rows, total: parseInt(count.rows[0].count) };
+            }
             const { rows } = await db.query(query, queryParams);
-            
-            return rows;
+            return { rows, total: rows.length };
         } catch (error) {
             console.error('Error in getAllReservationPayments:', error);
             throw error;

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -90,17 +90,13 @@ export default class ReviewModel {
 
         try {
             updatedValues.push(id);
-            const query = `UPDATE reviews SET ${updateFields.join(', ')} WHERE id = $${paramCount};`
-            await db.query(query, updatedValues);
+            const query = `UPDATE reviews SET ${updateFields.join(', ')} WHERE id = $${paramCount} RETURNING *;`
+            const { rows } = await db.query(query, updatedValues);
 
-            const { rows } = await db.query('SELECT * FROM reviews WHERE id = $1', [id]);
-
-            if (rows.length > 0) {
-                const updatedReview = rows[0];
-                return updatedReview;
-            } else {
+            if (rows.length === 0) {
                 throw new Error('Review not found');
             }
+            return rows[0];
         } catch (error) {
             throw error;
         }

--- a/src/models/supplier.ts
+++ b/src/models/supplier.ts
@@ -1,20 +1,19 @@
 import db from '../utils/db_render.js';
 import { Supplier, CreateSupplierDTO, UpdateSupplierDTO } from '../types/suppliers.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export class SupplierModel {
-    static async getAll(): Promise<Supplier[]> {
-        const { rows } = await db.query(`
-            SELECT
-                id,
-                name,
-                company,
-                email,
-                phone,
-                created_at as "createdAt"
-            FROM suppliers
-            ORDER BY name ASC
-        `);
-        return rows;
+    static async getAll(pagination?: PaginationParams): Promise<{ rows: Supplier[], total: number }> {
+        const base = `SELECT id, name, company, email, phone, created_at as "createdAt" FROM suppliers ORDER BY name ASC`;
+        if (pagination) {
+            const [data, count] = await Promise.all([
+                db.query(base + ' LIMIT $1 OFFSET $2', [pagination.limit, pagination.offset]),
+                db.query('SELECT COUNT(*) FROM suppliers'),
+            ]);
+            return { rows: data.rows, total: parseInt(count.rows[0].count) };
+        }
+        const { rows } = await db.query(base);
+        return { rows, total: rows.length };
     }
 
     static async getById(id: number): Promise<Supplier | null> {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -2,9 +2,10 @@ import db from '../utils/db_render.js';
 import { Client } from '../types/index.js';
 import { validateUser } from '../schemas/userSchema.js';
 import type { UserFilters } from '../schemas/userSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export default class UserModel {
-    static async getAll(filters?: UserFilters): Promise<Client[]> {
+    static async getAll(filters?: UserFilters, pagination?: PaginationParams): Promise<{ rows: Client[], total: number }> {
         try {
             const conditions: string[] = [];
             const values: any[] = [];
@@ -26,16 +27,20 @@ export default class UserModel {
                 conditions.push(`phone ILIKE $${values.length}`);
             }
 
-            const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-            const baseQuery = 'SELECT * FROM clients';
-            const query = whereClause ? `${baseQuery} ${whereClause}` : baseQuery;
+            const whereClause = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
 
-            const { rows } = await db.query(query, values);
-            return rows;
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(`SELECT * FROM clients${whereClause} ORDER BY id ASC LIMIT $${values.length + 1} OFFSET $${values.length + 2}`, [...values, pagination.limit, pagination.offset]),
+                    db.query(`SELECT COUNT(*) FROM clients${whereClause}`, values),
+                ]);
+                return { rows: data.rows, total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(`SELECT * FROM clients${whereClause} ORDER BY id ASC`, values);
+            return { rows, total: rows.length };
         } catch (error) {
             console.error('Error en getAll:', error);
-            // En lugar de propagar el error, devolvemos un array vacío
-            return [];
+            return { rows: [], total: 0 };
         }
     }
 

--- a/src/models/villa.ts
+++ b/src/models/villa.ts
@@ -1,6 +1,7 @@
 import db from '../utils/db_render.js';
 import { Villa, CreateVillaDTO, UpdateVillaDTO } from '../types/index.js';
 import { validateVilla, validatePartialVilla } from '../schemas/villaSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export default class VillaModel {
     /**
@@ -30,26 +31,33 @@ export default class VillaModel {
             .filter((url: string | null): url is string => url !== null && url.trim() !== '');
     }
 
-    static async getAll(): Promise<Villa[]> {
+    private static processVillaImages(rows: any[]): Villa[] {
+        return rows.map(villa => {
+            if (typeof villa.images === 'string') {
+                try { villa.images = this.normalizeImageArray(JSON.parse(villa.images)); }
+                catch { villa.images = []; }
+            } else if (Array.isArray(villa.images)) {
+                villa.images = this.normalizeImageArray(villa.images);
+            } else {
+                villa.images = [];
+            }
+            return villa;
+        });
+    }
+
+    static async getAll(pagination?: PaginationParams): Promise<{ rows: Villa[], total: number }> {
         try {
-            const { rows } = await db.query('SELECT * FROM villas');
-            return rows.map(villa => {
-                if (typeof villa.images === 'string') {
-                    try {
-                        villa.images = this.normalizeImageArray(JSON.parse(villa.images));
-                    } catch (error) {
-                        console.error('Error parsing villa images:', error);
-                        villa.images = [];
-                    }
-                } else if (Array.isArray(villa.images)) {
-                    villa.images = this.normalizeImageArray(villa.images);
-                } else {
-                    villa.images = [];
-                }
-                return villa;
-            });
+            const base = 'SELECT * FROM villas ORDER BY id ASC';
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(base + ' LIMIT $1 OFFSET $2', [pagination.limit, pagination.offset]),
+                    db.query('SELECT COUNT(*) FROM villas'),
+                ]);
+                return { rows: this.processVillaImages(data.rows), total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(base);
+            return { rows: this.processVillaImages(rows), total: rows.length };
         } catch (error) {
-            console.error('Error getting all villas:', error);
             throw new Error('Database error');
         }
     }

--- a/src/models/yacht.ts
+++ b/src/models/yacht.ts
@@ -1,6 +1,7 @@
 import db from '../utils/db_render.js';
 import { Yacht, CreateYachtDTO, UpdateYachtDTO } from '../types/index.js';
 import { validateYacht, validatePartialYacht } from '../schemas/yachtSchema.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export default class YachtModel {
     /**
@@ -30,29 +31,36 @@ export default class YachtModel {
             .filter((url: string | null): url is string => url !== null && url.trim() !== '');
     }
 
-    static async getAll(): Promise<Yacht[]> {
+    private static processYachtImages(rows: any[]): Yacht[] {
+        return rows.map(yacht => {
+            if (typeof yacht.images === 'string') {
+                try { yacht.images = this.normalizeImageArray(JSON.parse(yacht.images)); }
+                catch { yacht.images = []; }
+            } else if (Array.isArray(yacht.images)) {
+                yacht.images = this.normalizeImageArray(yacht.images);
+            } else {
+                yacht.images = [];
+            }
+            return yacht;
+        });
+    }
+
+    static async getAll(pagination?: PaginationParams): Promise<{ rows: Yacht[], total: number }> {
         try {
-            const { rows } = await db.query('SELECT * FROM yachts');
-            return rows.map(yacht => {
-                if (typeof yacht.images === 'string') {
-                    try {
-                        yacht.images = this.normalizeImageArray(JSON.parse(yacht.images));
-                    } catch (error) {
-                        console.error('Error parsing yacht images:', error);
-                        yacht.images = [];
-                    }
-                } else if (Array.isArray(yacht.images)) {
-                    yacht.images = this.normalizeImageArray(yacht.images);
-                } else {
-                    yacht.images = [];
-                }
-                return yacht;
-            });
+            const base = 'SELECT * FROM yachts ORDER BY id ASC';
+            if (pagination) {
+                const [data, count] = await Promise.all([
+                    db.query(base + ' LIMIT $1 OFFSET $2', [pagination.limit, pagination.offset]),
+                    db.query('SELECT COUNT(*) FROM yachts'),
+                ]);
+                return { rows: this.processYachtImages(data.rows), total: parseInt(count.rows[0].count) };
+            }
+            const { rows } = await db.query(base);
+            return { rows: this.processYachtImages(rows), total: rows.length };
         } catch (error) {
-            console.error('Error getting all yachts:', error);
             throw new Error('Database error');
         }
-    }   
+    }
 
     static async getYachtById(id: number): Promise<Yacht | null> {
         try {

--- a/src/routes/googleMyBusiness.ts
+++ b/src/routes/googleMyBusiness.ts
@@ -12,9 +12,9 @@ const router = Router();
 router.get('/auth-status', GoogleMyBusinessController.getAuthStatus);
 
 // Iniciar proceso de autenticación OAuth
-router.get('/auth/start', GoogleMyBusinessController.startAuth);
+router.get('/auth/start', authMiddleware, GoogleMyBusinessController.startAuth);
 
-// Callback de OAuth
+// Callback de OAuth — debe ser público, Google lo invoca directamente
 router.get('/callback', GoogleMyBusinessController.handleCallback);
 
 // ===========================================
@@ -22,10 +22,10 @@ router.get('/callback', GoogleMyBusinessController.handleCallback);
 // ===========================================
 
 // Obtener reviews desde Google API (sin guardar)
-router.get('/reviews/fetch', GoogleMyBusinessController.fetchReviews);
+router.get('/reviews/fetch', authMiddleware, GoogleMyBusinessController.fetchReviews);
 
 // Sincronizar reviews (fetch + save)
-router.post('/reviews/sync', GoogleMyBusinessController.syncReviews);
+router.post('/reviews/sync', authMiddleware, GoogleMyBusinessController.syncReviews);
 
 // Obtener reviews desde base de datos local
 router.get('/reviews', GoogleMyBusinessController.getLocalReviews);

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -4,9 +4,9 @@ import { authMiddleware } from '../middleware/authMiddleware.js'
 
 const router = Router()
 
-router.get('/', UserController.getAllUsers)
-router.get('/:id', UserController.getUserById)
-router.post('/', UserController.createUser)
+router.get('/', authMiddleware, UserController.getAllUsers)
+router.get('/:id', authMiddleware, UserController.getUserById)
+router.post('/', authMiddleware, UserController.createUser)
 router.put('/:id', authMiddleware, UserController.updateUser)
 router.delete('/:id', authMiddleware, UserController.deleteUser)
 

--- a/src/services/monthlySummaryService.ts
+++ b/src/services/monthlySummaryService.ts
@@ -8,22 +8,18 @@ export default class MonthlySummaryService {
    static async generateMonthlySummary(month: number, year: number): Promise<MonthlySummary>
     {
         try {
-            // Obtener datos del mes
-            const reservations = await MonthlySummaryModel.getReservationsByMonth(month, year);
-            const payments = await MonthlySummaryModel.getPaymentsByMonth(month, year);
+            const [reservations, payments, existingSummary] = await Promise.all([
+                MonthlySummaryModel.getReservationsByMonth(month, year),
+                MonthlySummaryModel.getPaymentsByMonth(month, year),
+                MonthlySummaryModel.getSummaryByMonthAndYear(month, year),
+            ]);
 
-            // Calcular totales
             const totalReservations = reservations.length;
             const totalPayments = payments.length;
-
-            // Asegurarnos de que los montos sean números y sumarlos correctamente
             const totalRevenue = payments.reduce((sum, payment) => {
                 const amount = Number(payment.amount) || 0;
                 return sum + amount;
             }, 0);
-
-            // Verificar si el resumen ya existe
-            const existingSummary = await MonthlySummaryModel.getSummaryByMonthAndYear(month, year);
 
             if (existingSummary) {
                 // Actualizar resumen existente
@@ -81,11 +77,12 @@ export default class MonthlySummaryService {
     
     static async generateSummaryPdf(month: number, year: number): Promise<Buffer> {
         try {
-            // Obtener datos detallados
-            const reservations = await MonthlySummaryModel.getReservationsByMonth(month, year);
-            const payments = await MonthlySummaryModel.getPaymentsByMonth(month, year);
+            const [reservations, payments, existingSummary] = await Promise.all([
+                MonthlySummaryModel.getReservationsByMonth(month, year),
+                MonthlySummaryModel.getPaymentsByMonth(month, year),
+                MonthlySummaryModel.getSummaryByMonthAndYear(month, year),
+            ]);
 
-            // Calcular totales
             const totalReservations = reservations.length;
             const totalPayments = payments.length;
             const totalRevenue = payments.reduce((sum, payment) => {
@@ -93,11 +90,9 @@ export default class MonthlySummaryService {
                 return sum + amount;
             }, 0);
 
-            // Crear o actualizar el resumen
-            let summary = await MonthlySummaryModel.getSummaryByMonthAndYear(month, year);
-            
+            let summary = existingSummary;
+
             if (summary) {
-                // Actualizar el resumen existente
                 summary = await MonthlySummaryModel.updateSummary(summary.id, {
                     totalReservations,
                     totalPayments,
@@ -138,15 +133,15 @@ export default class MonthlySummaryService {
 
     static async getSummaryDetails(month: number, year: number) {
         try {
-            // Obtener el resumen
             const summary = await MonthlySummaryModel.getSummaryByMonthAndYear(month, year);
             if (!summary) {
                 throw new Error('Summary not found');
             }
 
-            // Obtener datos detallados
-            const reservations = await MonthlySummaryModel.getReservationsByMonth(month, year);
-            const payments = await MonthlySummaryModel.getPaymentsByMonth(month, year);
+            const [reservations, payments] = await Promise.all([
+                MonthlySummaryModel.getReservationsByMonth(month, year),
+                MonthlySummaryModel.getPaymentsByMonth(month, year),
+            ]);
 
             return {
                 summary,

--- a/src/services/pdfService.ts
+++ b/src/services/pdfService.ts
@@ -758,7 +758,7 @@ export default class PdfService {
             // Si es un string y tiene el formato MM-DD-YYYY HH:mm
             if (typeof date === 'string') {
                 // Verificar si es el nuevo formato MM-DD-YYYY HH:mm
-                const dateTimeRegex = /^(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])-\d{4} (0[0-9]|1[0-9]|2[3]):([0-5][0-9])$/;
+                const dateTimeRegex = /^(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])-\d{4} (0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$/;
                 if (dateTimeRegex.test(date)) {
                     return date; // Ya está en el formato deseado, lo devolvemos tal cual
                 }
@@ -790,14 +790,18 @@ export default class PdfService {
 
     private static getStatusInEnglish(status: string | undefined): string | undefined {
         switch (status) {
-            case 'Confirmed':
+            case 'confirmed':
                 return 'Confirmed';
-            case 'Cancelled':
+            case 'cancelled':
                 return 'Cancelled';
-            case 'Pending':
+            case 'pending':
                 return 'Pending';
-            case 'Completed':
+            case 'completed':
                 return 'Completed';
+            case 'checked_in':
+                return 'Checked In';
+            case 'checked_out':
+                return 'Checked Out';
             default:
                 return undefined;
         }

--- a/src/services/reservationPaymentsService.ts
+++ b/src/services/reservationPaymentsService.ts
@@ -78,9 +78,8 @@ export default class ReservationPaymentsService {
         q?: string,
         clientLastname?: string,
         reservationId?: number
-        // status?: string - comentado temporalmente porque la columna no existe
-    } = {}): Promise<ReservationPayment[]> {
-        return ReservationPaymentModel.getAllReservationPayments(filters);
+    } = {}, pagination?: import('../utils/pagination.js').PaginationParams): Promise<{ rows: ReservationPayment[], total: number }> {
+        return ReservationPaymentModel.getAllReservationPayments(filters, pagination);
     }
 
     static async getPaymentById(paymentId: number): Promise<ReservationPayment | null> {

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -163,8 +163,8 @@ export default class ReservationService {
 
     // Otros métodos CRUD simplificados (sin lógica de email)
     static async getAllReservations(filters: {
-        startDate?: string, // Cambiado de Date a string
-        endDate?: string,   // Cambiado de Date a string
+        startDate?: string,
+        endDate?: string,
         status?: string,
         clientName?: string,
         clientEmail?: string,
@@ -173,8 +173,8 @@ export default class ReservationService {
         upcoming?: boolean,
         fromDate?: string,
         withinDays?: number
-    } = {}): Promise<Reservation[]> {
-        return ReservationModel.getAllReservations(filters);
+    } = {}, pagination?: import('../utils/pagination.js').PaginationParams): Promise<{ rows: Reservation[], total: number }> {
+        return ReservationModel.getAllReservations(filters, pagination);
     }
     
     static async getReservationById(id: number): Promise<Reservation | null> {

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -45,8 +45,8 @@ function formatReservationSupplier(row: ReservationSupplier): ReservationSupplie
 export default class SupplierService {
     // --- Suppliers CRUD ---
 
-    static async getAllSuppliers(): Promise<Supplier[]> {
-        return SupplierModel.getAll();
+    static async getAllSuppliers(pagination?: import('../utils/pagination.js').PaginationParams): Promise<{ rows: Supplier[], total: number }> {
+        return SupplierModel.getAll(pagination);
     }
 
     static async getSupplierById(id: number): Promise<Supplier> {

--- a/src/utils/db_render.ts
+++ b/src/utils/db_render.ts
@@ -17,6 +17,9 @@ function getPool(): pg.Pool {
             ssl: process.env.DB_SSL === 'true' ? {
                 rejectUnauthorized: false
             } : false,
+            max: 5,                       // Render hobby DB tiene límite bajo de conexiones
+            idleTimeoutMillis: 30000,     // libera conexiones idle después de 30s
+            connectionTimeoutMillis: 5000, // falla rápido en lugar de colgar indefinidamente
         });
 
         pool.on('connect', (client) => {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -17,7 +17,7 @@ export interface PaginatedResponse<T> {
 export function parsePagination(query: Record<string, any>): PaginationParams | null {
     if (!query.page && !query.limit) return null;
     const page = Math.max(1, parseInt(query.page as string) || 1);
-    const limit = Math.min(100, Math.max(1, parseInt(query.limit as string) || 20));
+    const limit = Math.min(20, Math.max(1, parseInt(query.limit as string) || 20));
     return { page, limit, offset: (page - 1) * limit };
 }
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,34 @@
+export interface PaginationParams {
+    page: number;
+    limit: number;
+    offset: number;
+}
+
+export interface PaginatedResponse<T> {
+    data: T[];
+    pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+    };
+}
+
+export function parsePagination(query: Record<string, any>): PaginationParams | null {
+    if (!query.page && !query.limit) return null;
+    const page = Math.max(1, parseInt(query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit as string) || 20));
+    return { page, limit, offset: (page - 1) * limit };
+}
+
+export function paginatedResponse<T>(rows: T[], total: number, params: PaginationParams): PaginatedResponse<T> {
+    return {
+        data: rows,
+        pagination: {
+            page: params.page,
+            limit: params.limit,
+            total,
+            totalPages: Math.ceil(total / params.limit),
+        },
+    };
+}


### PR DESCRIPTION
## Resumen

Auditoría completa de seguridad y performance aplicada sobre la rama `main`. Todos los cambios fueron probados en local y las migraciones aplicadas en producción.

## Seguridad

- **Auth en rutas de usuarios**: `GET /users`, `GET /users/:id`, `POST /users` ahora requieren JWT — exponían PII de clientes sin autenticación
- **Auth en Google My Business**: endpoints de admin (`/auth/start`, `/reviews/fetch`, `/reviews/sync`) protegidos con JWT
- **Rate limiting global**: 200 req/15min en toda la API; 30 req/15min en endpoints de upload de imágenes
- **JWT algorithms pinned**: `{ algorithms: ['HS256'] }` en `authMiddleware` para prevenir algorithm confusion attacks

## Performance / Base de datos

- **Pool de conexiones configurado**: `max: 5`, `idleTimeoutMillis: 30s`, `connectionTimeoutMillis: 5s` — evita agotamiento de conexiones en Render
- **Migration 020**: índices FK faltantes en `reservation_suppliers` y `supplier_payments`
- **Migration 021**: función IMMUTABLE `mga_parse_date()` + expression indexes en `check_in_date` y `check_out_date` — queries de reservaciones ahora pueden usar index scan en lugar de seq scan
- **Monthly summary**: queries de reservaciones y pagos corren en paralelo con `Promise.all`; predicado de fecha cambiado de `EXTRACT` a range (permite uso del índice)
- **UPDATE RETURNING \***: elimina un SELECT extra en updates de apartments y reviews

## Bug fixes

- **PDF — estados incorrectos**: `getStatusInEnglish` siempre devolvía "Confirmed" por mismatch de mayúsculas con el enum de la DB
- **PDF — fechas inválidas**: regex `2[3]` → `2[0-3]` hacía fallar el parsing de horas entre 20:00 y 22:59
- **Reserva huérfana**: si el pago inicial fallaba al crear una reserva, la reserva quedaba en la DB sin pago. Ahora se elimina con compensating delete. Migration 022 agrega `ON DELETE CASCADE` al FK de `reservation_payments`
- **Multer errors**: subir archivos >10MB devolvía 500 genérico; ahora devuelve 400 con mensaje claro

## Validación

- **Villa y yacht update**: reemplaza validaciones manuales `isNaN` con `validatePartialVilla` / `validatePartialYacht` de Zod, consistente con apartment y car

## Nueva feature: Paginación

Todos los endpoints de listado soportan paginación opt-in (sin params = comportamiento anterior, sin breaking changes):

```
GET /api/apartments?page=1&limit=20
```

Respuesta paginada:
```json
{
  "data": [...],
  "pagination": { "page": 1, "limit": 20, "total": 47, "totalPages": 3 }
}
```

Endpoints con paginación: apartments, cars, villas, yachts, reservations, reservation-payments, users, suppliers. Límite máximo: 20 items/página.

## Migraciones en producción

Las migraciones 020, 021 y 022 ya fueron aplicadas en la DB de producción (Render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)