### PR TITLE
feat: GET /api/supplier-payments + migration 026 + enum method update

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -33,6 +33,7 @@ Backend REST API para **MiamiGetAway**, plataforma de alquiler de propiedades y 
 | Reservaciones | `/api/reservations` | Todos |
 | Pagos de reservaciones | `/api/reservation-payments` | Todos |
 | Suppliers | `/api/suppliers` | Todos |
+| Pagos a suppliers | `/api/supplier-payments` | Todos |
 | Resúmenes mensuales | `/api/summaries` | Todos |
 | Google My Business | `/api/google-mybusiness` | Solo admin endpoints |
 | Cron | `/api/cron` | Sí |
@@ -64,48 +65,30 @@ Backend REST API para **MiamiGetAway**, plataforma de alquiler de propiedades y 
 
 ---
 
-## Migraciones
+## Migraciones (actualizado 2026-06-24)
 
 Scripts SQL en `migrations/scripts/`. Usar `runSingle.js` de a una, nunca `index.js` en producción.
 
-| # | Descripción | Entorno |
+| # | Descripción | Estado |
 |---|---|---|
-| 000-008 | Base del schema | prod |
-| 009-010 | Google OAuth tokens y reviews | prod |
-| 011 | Performance indexes | prod |
-| 012 | receipt_image en reservation_payments | prod |
-| 013 | Tabla suppliers, reservation_suppliers, supplier_payments | prod |
-| 014 | Amount columns en reservations | prod |
-| 015 | payment_reference en payments | prod |
+| 000-008 | Base del schema | prod + local |
+| 009-010 | Google OAuth tokens y reviews | prod + local |
+| 011 | Performance indexes | prod + local |
+| 012 | receipt_image en reservation_payments | prod + local |
+| 013 | Tabla suppliers, reservation_suppliers, supplier_payments | prod + local |
+| 014 | Amount columns en reservations | prod + local |
+| 015 | payment_reference en payments | prod + local |
 | 016 | **ELIMINADA** (era RENAME COLUMN) | — |
-| 017 | cleaning_fee en reservation_suppliers | prod |
-| 018 | Normaliza payment_status 'complete' → 'completed' | prod |
-| 019 | Tabla investments | prod |
-| 020 | Indexes FK en supplier tables | prod |
-| 021 | mga_parse_date() IMMUTABLE + expression indexes | prod |
-| 022 | ON DELETE CASCADE en reservation_payments | prod |
-| 023 | Tablas experiences + experience_inquiries | prod |
-| 024 | Tablas transfer_vehicles + transfer_inquiries | prod |
-| 025 | luggage_large/medium/carry_on en transfer_inquiries | prod |
-| 026 | Actualiza CHECK constraint métodos de pago supplier | prod — **⚠️ pendiente en BD local** |
-
----
-
-## Estado de ramas y features del cliente
-
-> Última sesión: `docs/memory/2026-06-23.md`
-> Documentos de referencia:
-> - `docs/api-frontend-contract.md` — contrato general API ↔ Frontend
-> - `docs/investments-frontend-contract.md` — contrato investments
-> - `docs/experiences-frontend-contract.md` — contrato experiences
-> - `docs/transfers-frontend-contract.md` — contrato transfers
-> - `docs/presupuesto.md` — presupuesto técnico ($1.500 USD)
-
-| Feature | Rama | Estado |
-|---|---|---|
-| Investments | `main` | ✅ en producción |
-| Experiences | `main` | ✅ en producción |
-| Transfers | `main` | ✅ en producción |
+| 017 | cleaning_fee en reservation_suppliers | prod + local |
+| 018 | Normaliza payment_status 'complete' → 'completed' | prod + local |
+| 019 | Tabla investments | prod + local |
+| 020 | Indexes FK en supplier tables | prod + local |
+| 021 | mga_parse_date() IMMUTABLE + expression indexes | prod + local |
+| 022 | ON DELETE CASCADE en reservation_payments | prod + local |
+| 023 | Tablas experiences + experience_inquiries | prod + local |
+| 024 | Tablas transfer_vehicles + transfer_inquiries | prod + local |
+| 025 | luggage_large/medium/carry_on en transfer_inquiries | prod + local |
+| 026 | Actualiza CHECK constraint métodos de pago supplier | prod + local ✅ |
 
 ---
 
@@ -119,6 +102,30 @@ Scripts SQL en `migrations/scripts/`. Usar `runSingle.js` de a una, nunca `index
 
 ---
 
-## Pendientes
+## Estado de ramas y features
 
-- ⚠️ Correr migration 026 en BD local: `npx cross-env NODE_ENV=test ENV_FILE=.env.test node migrations/runSingle.js 026_update_supplier_payment_method_enum.sql`
+> Última sesión: `docs/memory/2026-06-24.md`
+> Documentos de referencia:
+> - `docs/api-frontend-contract.md` — contrato general API ↔ Frontend
+> - `docs/investments-frontend-contract.md` — contrato investments
+> - `docs/experiences-frontend-contract.md` — contrato experiences
+> - `docs/transfers-frontend-contract.md` — contrato transfers
+
+| Feature | Rama | Estado |
+|---|---|---|
+| Investments | `main` | ✅ en producción |
+| Experiences | `main` | ✅ en producción |
+| Transfers | `main` | ✅ en producción |
+| GET /supplier-payments | PR #43 `development → main` | ✅ pendiente merge |
+
+---
+
+## Endpoint: GET /api/supplier-payments (2026-06-24)
+
+Devuelve pagos a proveedores con contexto completo. Auth: JWT.
+
+**Query params:** `supplierId`, `reservationId`, `startDate` (YYYY-MM-DD), `endDate` (YYYY-MM-DD), `page`, `limit`
+
+**Response:** `{ data[], pagination, summary }` — `summary` es `null` sin `supplierId`; con él incluye `{ totalPaid, totalOwed, balance }` calculado sobre **todas** las reservas del supplier.
+
+**JOIN chain:** `supplier_payments → reservation_suppliers → reservations → apartments → suppliers`

--- a/docs/memory/2026-06-24.md
+++ b/docs/memory/2026-06-24.md
@@ -1,0 +1,86 @@
+# Sesión 2026-06-24
+
+## Qué se hizo
+
+### 1. Migration 026 traída a `development`
+
+El archivo `026_update_supplier_payment_method_enum.sql` estaba en `main` pero no en `development`.
+Se trajo con `git checkout main -- migrations/scripts/026_...` y se corrió en la BD local.
+Commiteado en `development`.
+
+### 2. Diagnóstico N+1 en pagos de reservaciones
+
+**Síntoma:** nombres de clientes quedaban en "loading" y la API recibía 200+ requests a `/api/reservations/:id` por cada carga de la pantalla de pagos.
+
+**Causa:** `normalizePaymentFromApi` en el front no mapeaba `clientName`, `clientLastname`, `clientEmail`. El componente hacía un fetch por reserva para obtener el clientId y otro para obtener el nombre del cliente.
+
+**Solución (frontend):** agregar los 3 campos al normalizer — el backend ya los incluye en el JOIN del `GET /api/reservation-payments`.
+
+### 3. Diagnóstico mismo problema en lista de reservaciones
+
+`apartmentName` ya viene en la respuesta de `GET /api/reservations` (línea 48 del model, JOIN con `apartments`). El front solo necesita mapearlo en su normalizer.
+
+### 4. Nuevo endpoint: `GET /api/supplier-payments`
+
+**Rama:** `feature/reservation-payments-improvements` (creada desde `development`)
+
+**Archivos modificados:**
+- `src/types/suppliers.ts` — nuevas interfaces `SupplierPaymentWithDetails`, `SupplierPaymentSummary`; nuevo tipo `SupplierPaymentMethod`; enum de method actualizado (elimina `wire`, agrega `paypal`, `zelle`, `stripe`, `other`)
+- `src/schemas/suppliersSchema.ts` — enum Zod actualizado igual
+- `src/models/supplierPayment.ts` — nuevo método `getAll(filters, pagination)`
+- `src/services/supplierService.ts` — nuevo método `getAllSupplierPayments`
+- `src/controllers/suppliers.ts` — nuevo handler `SupplierPaymentController.getAll`
+- `src/routes/suppliers.ts` — `GET /` montado en `supplierPaymentsRouter`
+
+**Endpoint:**
+
+```
+GET /api/supplier-payments
+Auth: JWT requerido
+
+Query params:
+  supplierId     number   (opcional)
+  reservationId  number   (opcional)
+  startDate      YYYY-MM-DD (opcional)
+  endDate        YYYY-MM-DD (opcional)
+  page           number   default 1
+  limit          number   default 20
+
+Response:
+{
+  data: [...],           // SupplierPaymentWithDetails[]
+  pagination: { page, limit, total, totalPages },
+  summary: {             // null si no se pasa supplierId
+    totalPaid: number,
+    totalOwed: number,
+    balance: number      // totalOwed - totalPaid
+  }
+}
+```
+
+**JOIN chain:** `supplier_payments → reservation_suppliers → reservations → apartments → suppliers`
+
+**Campos en cada item de `data`:**
+- Del pago: `id`, `amount`, `method`, `date` (YYYY-MM-DD), `referenceNotes`, `receiptImages`, `createdAt`
+- Del supplier: `supplierId`, `supplierName`, `supplierEmail`, `supplierPhone`
+- De la reserva/apt: `reservationId`, `apartmentName`, `checkInDate`, `checkOutDate`, `nights`
+
+**Summary:** cuando se filtra por `supplierId`, calcula sobre **todas** sus reservas (no solo la página actual).
+- `totalPaid` = suma de todos los pagos hechos al supplier
+- `totalOwed` = suma de `(payout_per_night × nights + cleaning_fee)` por cada `reservation_suppliers`
+- `balance` = `totalOwed - totalPaid`
+
+---
+
+## Estado de ramas al cierre
+
+| Rama | Estado |
+|------|--------|
+| `main` | Producción, migraciones hasta 026 |
+| `development` | main + migration 026 commiteada |
+| `feature/reservation-payments-improvements` | development + GET /supplier-payments |
+
+## Pendientes
+
+- Mergear `feature/reservation-payments-improvements` → `development` → `main` cuando esté validado con el front
+- Front debe actualizar normalizadores (ver indicaciones en esta misma sesión)

--- a/src/controllers/suppliers.ts
+++ b/src/controllers/suppliers.ts
@@ -189,6 +189,49 @@ export class ReservationSupplierController {
 // ---- Supplier payments ----
 
 export class SupplierPaymentController {
+    static async getAll(req: Request, res: Response): Promise<void> {
+        try {
+            const filters: { supplierId?: number; reservationId?: number; startDate?: string; endDate?: string } = {};
+
+            if (req.query.supplierId) {
+                const supplierId = parseInt(req.query.supplierId as string);
+                if (isNaN(supplierId)) { res.status(400).json({ error: 'supplierId must be a valid number' }); return; }
+                filters.supplierId = supplierId;
+            }
+
+            if (req.query.reservationId) {
+                const reservationId = parseInt(req.query.reservationId as string);
+                if (isNaN(reservationId)) { res.status(400).json({ error: 'reservationId must be a valid number' }); return; }
+                filters.reservationId = reservationId;
+            }
+
+            const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+            if (req.query.startDate) {
+                const startDate = req.query.startDate as string;
+                if (!dateRegex.test(startDate)) { res.status(400).json({ error: 'startDate format is invalid. Use YYYY-MM-DD' }); return; }
+                filters.startDate = startDate;
+            }
+
+            if (req.query.endDate) {
+                const endDate = req.query.endDate as string;
+                if (!dateRegex.test(endDate)) { res.status(400).json({ error: 'endDate format is invalid. Use YYYY-MM-DD' }); return; }
+                filters.endDate = endDate;
+            }
+
+            const pagination = parsePagination(req.query);
+            const { rows, total, summary } = await SupplierService.getAllSupplierPayments(filters, pagination ?? undefined);
+
+            if (pagination) {
+                res.status(200).json({ ...paginatedResponse(rows, total, pagination), summary });
+            } else {
+                res.status(200).json({ data: rows, summary });
+            }
+        } catch (error: any) {
+            res.status(500).json({ error: error.message });
+        }
+    }
+
     static async getByReservationSupplier(req: Request, res: Response): Promise<void> {
         try {
             const reservationSupplierId = parseInt(req.params.reservationSupplierId);

--- a/src/models/supplierPayment.ts
+++ b/src/models/supplierPayment.ts
@@ -1,5 +1,6 @@
 import db from '../utils/db_render.js';
-import { SupplierPayment, CreateSupplierPaymentDTO, UpdateSupplierPaymentDTO } from '../types/suppliers.js';
+import { SupplierPayment, SupplierPaymentWithDetails, SupplierPaymentSummary, CreateSupplierPaymentDTO, UpdateSupplierPaymentDTO } from '../types/suppliers.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 export class SupplierPaymentModel {
     static async getByReservationSupplier(reservationSupplierId: number): Promise<SupplierPayment[]> {
@@ -97,5 +98,109 @@ export class SupplierPaymentModel {
     static async delete(id: number): Promise<boolean> {
         const { rowCount } = await db.query('DELETE FROM supplier_payments WHERE id = $1', [id]);
         return (rowCount ?? 0) > 0;
+    }
+
+    static async getAll(
+        filters: {
+            supplierId?: number;
+            reservationId?: number;
+            startDate?: string;
+            endDate?: string;
+        } = {},
+        pagination?: PaginationParams
+    ): Promise<{ rows: SupplierPaymentWithDetails[], total: number, summary: SupplierPaymentSummary | null }> {
+        const queryParams: any[] = [];
+        const conditions: string[] = [];
+
+        if (filters.supplierId) {
+            queryParams.push(filters.supplierId);
+            conditions.push(`rs.supplier_id = $${queryParams.length}`);
+        }
+
+        if (filters.reservationId) {
+            queryParams.push(filters.reservationId);
+            conditions.push(`rs.reservation_id = $${queryParams.length}`);
+        }
+
+        if (filters.startDate) {
+            queryParams.push(filters.startDate);
+            conditions.push(`sp.date >= $${queryParams.length}::date`);
+        }
+
+        if (filters.endDate) {
+            queryParams.push(filters.endDate);
+            conditions.push(`sp.date <= $${queryParams.length}::date`);
+        }
+
+        const whereClause = conditions.length > 0 ? ' WHERE ' + conditions.join(' AND ') : '';
+
+        const baseFrom = `
+            FROM supplier_payments sp
+            JOIN reservation_suppliers rs ON sp.reservation_supplier_id = rs.id
+            JOIN reservations r ON rs.reservation_id = r.id
+            LEFT JOIN apartments a ON r.apartment_id = a.id
+            JOIN suppliers s ON rs.supplier_id = s.id
+        `;
+
+        let dataQuery = `
+            SELECT
+                sp.id,
+                sp.amount,
+                sp.method,
+                to_char(sp.date, 'YYYY-MM-DD') as date,
+                sp.reference_notes as "referenceNotes",
+                sp.receipt_images as "receiptImages",
+                sp.created_at as "createdAt",
+                s.id as "supplierId",
+                s.name as "supplierName",
+                s.email as "supplierEmail",
+                s.phone as "supplierPhone",
+                r.id as "reservationId",
+                a.name as "apartmentName",
+                r.check_in_date as "checkInDate",
+                r.check_out_date as "checkOutDate",
+                r.nights
+            ${baseFrom}
+            ${whereClause}
+            ORDER BY sp.date DESC, sp.id DESC
+        `;
+
+        let summary: SupplierPaymentSummary | null = null;
+
+        if (filters.supplierId) {
+            const summaryResult = await db.query(`
+                SELECT
+                    COALESCE((
+                        SELECT SUM(sp2.amount)
+                        FROM supplier_payments sp2
+                        JOIN reservation_suppliers rs2 ON sp2.reservation_supplier_id = rs2.id
+                        WHERE rs2.supplier_id = $1
+                    ), 0) as total_paid,
+                    COALESCE((
+                        SELECT SUM(rs3.payout_per_night * r3.nights + rs3.cleaning_fee)
+                        FROM reservation_suppliers rs3
+                        JOIN reservations r3 ON rs3.reservation_id = r3.id
+                        WHERE rs3.supplier_id = $1
+                    ), 0) as total_owed
+            `, [filters.supplierId]);
+
+            const totalPaid = Number(summaryResult.rows[0].total_paid);
+            const totalOwed = Number(summaryResult.rows[0].total_owed);
+            summary = { totalPaid, totalOwed, balance: totalOwed - totalPaid };
+        }
+
+        if (pagination) {
+            const countQuery = `SELECT COUNT(*) ${baseFrom} ${whereClause}`;
+            queryParams.push(pagination.limit, pagination.offset);
+            dataQuery += ` LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}`;
+            const [data, count] = await Promise.all([
+                db.query(dataQuery, queryParams),
+                db.query(countQuery, queryParams.slice(0, -2)),
+            ]);
+            return { rows: data.rows, total: parseInt(count.rows[0].count), summary };
+        }
+
+        const { rows } = await db.query(dataQuery, queryParams);
+        return { rows, total: rows.length, summary };
     }
 }

--- a/src/routes/suppliers.ts
+++ b/src/routes/suppliers.ts
@@ -17,6 +17,7 @@ export default router;
 // Separate router for supplier payments (mounted at /api/supplier-payments)
 export const supplierPaymentsRouter = Router();
 
+supplierPaymentsRouter.get('/', authMiddleware, SupplierPaymentController.getAll);
 supplierPaymentsRouter.get(
     '/by-reservation-supplier/:reservationSupplierId',
     authMiddleware,

--- a/src/services/supplierService.ts
+++ b/src/services/supplierService.ts
@@ -11,9 +11,12 @@ import {
     ReservationSupplierResponse,
     AssignSupplierDTO,
     SupplierPayment,
+    SupplierPaymentWithDetails,
+    SupplierPaymentSummary,
     CreateSupplierPaymentDTO,
     UpdateSupplierPaymentDTO
 } from '../types/suppliers.js';
+import { PaginationParams } from '../utils/pagination.js';
 
 function formatReservationSupplier(row: ReservationSupplier): ReservationSupplierResponse {
     const total = Number(row.totalPayout ?? 0);
@@ -118,6 +121,13 @@ export default class SupplierService {
     }
 
     // --- Supplier payments ---
+
+    static async getAllSupplierPayments(
+        filters: { supplierId?: number; reservationId?: number; startDate?: string; endDate?: string } = {},
+        pagination?: PaginationParams
+    ): Promise<{ rows: SupplierPaymentWithDetails[], total: number, summary: SupplierPaymentSummary | null }> {
+        return SupplierPaymentModel.getAll(filters, pagination);
+    }
 
     static async getPaymentsByReservationSupplier(reservationSupplierId: number): Promise<SupplierPayment[]> {
         return SupplierPaymentModel.getByReservationSupplier(reservationSupplierId);

--- a/src/types/suppliers.ts
+++ b/src/types/suppliers.ts
@@ -69,11 +69,13 @@ export interface AssignSupplierDTO {
     payment_terms?: string;
 }
 
+export type SupplierPaymentMethod = 'cash' | 'card' | 'transfer' | 'paypal' | 'zelle' | 'stripe' | 'other';
+
 export interface SupplierPayment {
     id: number;
     reservationSupplierId: number;
     amount: number;
-    method: 'cash' | 'card' | 'transfer' | 'paypal' | 'zelle' | 'stripe' | 'other';
+    method: SupplierPaymentMethod;
     date: Date;
     referenceNotes?: string | null;
     receiptImages: string[];
@@ -83,7 +85,7 @@ export interface SupplierPayment {
 export interface CreateSupplierPaymentDTO {
     reservationSupplierId: number;
     amount: number;
-    method: 'cash' | 'card' | 'transfer' | 'paypal' | 'zelle' | 'stripe' | 'other';
+    method: SupplierPaymentMethod;
     date: string;
     referenceNotes?: string;
     receiptImages?: string[];
@@ -91,8 +93,33 @@ export interface CreateSupplierPaymentDTO {
 
 export interface UpdateSupplierPaymentDTO {
     amount?: number;
-    method?: 'cash' | 'card' | 'transfer' | 'paypal' | 'zelle' | 'stripe' | 'other';
+    method?: SupplierPaymentMethod;
     date?: string;
     referenceNotes?: string | null;
     receiptImages?: string[];
+}
+
+export interface SupplierPaymentWithDetails {
+    id: number;
+    amount: number;
+    method: SupplierPaymentMethod;
+    date: string;
+    referenceNotes?: string | null;
+    receiptImages: string[];
+    createdAt: Date;
+    supplierId: number;
+    supplierName: string;
+    supplierEmail?: string | null;
+    supplierPhone?: string | null;
+    reservationId: number;
+    apartmentName?: string | null;
+    checkInDate: string;
+    checkOutDate: string;
+    nights: number;
+}
+
+export interface SupplierPaymentSummary {
+    totalPaid: number;
+    totalOwed: number;
+    balance: number;
 }


### PR DESCRIPTION
## Summary

- **Nuevo endpoint** `GET /api/supplier-payments` — pagos a proveedores con contexto completo (supplier, reserva, apartamento). Filtros: `supplierId`, `reservationId`, `startDate`, `endDate`, `page`, `limit`. Incluye `summary` con `totalPaid`, `totalOwed` y `balance` cuando se filtra por supplier.
- **Migration 026** (`026_update_supplier_payment_method_enum.sql`) commiteada en el repo — actualiza el CHECK constraint de `supplier_payments.method` (elimina `wire`, agrega `paypal`, `zelle`, `stripe`, `other`).
- **Enum `SupplierPaymentMethod` actualizado** en tipos TypeScript y schema Zod para reflejar los valores vigentes en producción.

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `migrations/scripts/026_update_supplier_payment_method_enum.sql` | Nuevo (traído de main, ahora en development) |
| `src/types/suppliers.ts` | `SupplierPaymentMethod`, `SupplierPaymentWithDetails`, `SupplierPaymentSummary` |
| `src/schemas/suppliersSchema.ts` | Enum Zod actualizado |
| `src/models/supplierPayment.ts` | Método `getAll(filters, pagination)` |
| `src/services/supplierService.ts` | Método `getAllSupplierPayments` |
| `src/controllers/suppliers.ts` | Handler `SupplierPaymentController.getAll` |
| `src/routes/suppliers.ts` | `GET /` en `supplierPaymentsRouter` |
| `docs/MEMORY.md` + `docs/memory/2026-06-24.md` | Memoria del proyecto actualizada |

## Test plan

- [x] `GET /api/supplier-payments?page=1&limit=10` — devuelve `{ data, pagination, summary: null }`
- [x] `GET /api/supplier-payments?supplierId=X` — devuelve `summary` con `totalPaid`, `totalOwed`, `balance`
- [x] `GET /api/supplier-payments?reservationId=X` — filtra correctamente
- [x] `GET /api/supplier-payments?startDate=2026-01-01&endDate=2026-06-30` — filtra por fecha
- [x] Formato de `date` en cada item: `YYYY-MM-DD`
- [x] Formato de `checkInDate`/`checkOutDate`: `MM-DD-YYYY HH:mm`
- [x] Sin JWT → 401
- [x] `startDate` en formato inválido → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)