### PR TITLE
fix(reservations): sort upcoming reservations ASC

### DIFF
--- a/src/models/reservation.ts
+++ b/src/models/reservation.ts
@@ -122,7 +122,9 @@ export class ReservationModel {
             
             const whereClause = conditions.length > 0 ? ' WHERE ' + conditions.join(' AND ') : '';
             query += whereClause;
-            query += ` ORDER BY mga_parse_date(r.check_in_date) DESC`;
+            query += filters.upcoming
+                ? ` ORDER BY mga_parse_date(r.check_in_date) ASC`
+                : ` ORDER BY mga_parse_date(r.check_in_date) DESC`;
 
             if (pagination) {
                 const countQuery = `SELECT COUNT(*) FROM reservations r LEFT JOIN clients c ON r.client_id = c.id LEFT JOIN apartments a ON r.apartment_id = a.id${whereClause}`;


### PR DESCRIPTION
## Summary

- `GET /api/reservations?upcoming=true` ordenaba con `DESC`, devolviendo las reservas más lejanas primero (ej: octubre antes que julio)
- Fix: el `ORDER BY` ahora es `ASC` cuando `upcoming=true`, mostrando la reserva más próxima primero en página 1
- El resto de los endpoints sin `upcoming` siguen con `DESC` (sin cambio de comportamiento)

## Test plan

- [x] `GET /api/reservations?upcoming=true` → primera página muestra reservas con check-in más cercano a hoy
- [x] `GET /api/reservations?upcoming=true&page=1&limit=10` → paginación funciona correctamente con el nuevo orden
- [x] `GET /api/reservations` (sin upcoming) → orden no cambió, sigue DESC

🤖 Generated with [Claude Code](https://claude.com/claude-code)