### PR TITLE
fix: persistir borrado/orden de imágenes existentes en updates de servicios

### DIFF
--- a/src/__tests__/integration/apartment-routes.test.ts
+++ b/src/__tests__/integration/apartment-routes.test.ts
@@ -245,6 +245,7 @@ describe('Rutas de Apartamentos', () => {
         unitNumber: '1A'
       };
       
+      vi.mocked(ApartmentModel.getApartmentById).mockResolvedValueOnce({ ...updatedApartment, name: 'Apartment', price: 250 });
       vi.mocked(ApartmentModel.updateApartment).mockResolvedValueOnce(updatedApartment);
 
       // Realizar la petición
@@ -258,9 +259,15 @@ describe('Rutas de Apartamentos', () => {
       expect(response.body).toEqual(updatedApartment);
       expect(ApartmentModel.updateApartment).toHaveBeenCalledWith(1, expect.any(Object));
     });
-    
+
     // Tests de validación de campos inválidos
     it('debería validar correctamente los datos de actualización', async () => {
+      const mockExistingApartment = {
+        id: 1, name: 'Apartment', address: 'Address 1', capacity: 2, bathrooms: 1,
+        rooms: 1, price: 250, description: 'Description', images: [], unitNumber: '1A'
+      };
+      vi.mocked(ApartmentModel.getApartmentById).mockResolvedValue(mockExistingApartment);
+
       // Comprobamos que los diferentes casos de validación de errores funcionan
       // Test 1: Precio inválido
       const response1 = await request(app)
@@ -269,7 +276,7 @@ describe('Rutas de Apartamentos', () => {
 
       expect(response1.status).toBe(400);
       expect(response1.body).toHaveProperty('error', 'Invalid price value');
-      
+
       // Test 2: Capacidad inválida - necesitamos un nuevo request para evitar errores de cabecera
       const response2 = await request(app)
         .put('/api/apartments/2')
@@ -277,7 +284,7 @@ describe('Rutas de Apartamentos', () => {
 
       expect(response2.status).toBe(400);
       expect(response2.body).toHaveProperty('error', 'Valor inválido para capacity');
-      
+
       // Test 3: Baños inválidos
       const response3 = await request(app)
         .put('/api/apartments/3')
@@ -285,7 +292,7 @@ describe('Rutas de Apartamentos', () => {
 
       expect(response3.status).toBe(400);
       expect(response3.body).toHaveProperty('error', 'Valor inválido para bathrooms');
-      
+
       // Test 4: Habitaciones inválidas
       const response4 = await request(app)
         .put('/api/apartments/4')

--- a/src/__tests__/integration/car-routes.test.ts
+++ b/src/__tests__/integration/car-routes.test.ts
@@ -193,15 +193,16 @@ describe('Rutas de Autos', () => {
   describe('PUT /api/cars/:id', () => {
     it('debería actualizar un auto existente con datos válidos', async () => {
       // Mock para actualización
-      const updatedCar = { 
-        id: 1, 
-        brand: 'BMW', 
-        model: 'X7', 
-        description: 'Updated luxury SUV', 
-        price: 200, 
-        images: [] 
+      const updatedCar = {
+        id: 1,
+        brand: 'BMW',
+        model: 'X7',
+        description: 'Updated luxury SUV',
+        price: 200,
+        images: []
       };
-      
+
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
       vi.mocked(CarModel.updateCar).mockResolvedValueOnce(updatedCar);
 
       // Realizar la petición
@@ -221,6 +222,7 @@ describe('Rutas de Autos', () => {
     });
 
     it('debería retornar 400 con precio inválido', async () => {
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
       // Realizar la petición
       await request(app)
         .put('/api/cars/1')
@@ -242,6 +244,7 @@ describe('Rutas de Autos', () => {
           flatten: () => ({ formErrors: ['Brand cannot be empty'], fieldErrors: {} })
         }
       } as any);
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
 
       // Realizar la petición
       await request(app)

--- a/src/__tests__/unit/controllers/apartment.test.ts
+++ b/src/__tests__/unit/controllers/apartment.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../../services/imageService.js', () => ({
   default: {
     uploadImages: vi.fn().mockResolvedValue({ success: true, urls: ['https://test-url.com/image.jpg'], errors: [] }),
     deleteImages: vi.fn().mockResolvedValue({ success: true, errors: [] }),
+    syncImages: vi.fn().mockResolvedValue({ images: undefined }),
     optimizeForContext: vi.fn().mockImplementation((images: string[]) => ({ images, responsiveImages: [] }))
   }
 }));
@@ -303,7 +304,8 @@ describe('ApartmentController', () => {
         images: [],
         unitNumber: '1A'
       };
-      
+
+      vi.mocked(ApartmentModel.getApartmentById).mockResolvedValueOnce({ ...updatedApartment, name: 'Apartment', price: 1000 });
       vi.mocked(validatePartialApartment).mockReturnValueOnce({ success: true } as any);
       vi.mocked(ApartmentModel.updateApartment).mockResolvedValueOnce(updatedApartment);
 
@@ -326,6 +328,10 @@ describe('ApartmentController', () => {
       req.body = {
         price: 'invalid-price' // Precio inválido
       };
+      vi.mocked(ApartmentModel.getApartmentById).mockResolvedValueOnce({
+        id: 1, name: 'Apartment', address: '123 Main St', capacity: 4, bathrooms: 2,
+        rooms: 2, price: 1000, description: 'Nice apartment', images: [], unitNumber: '1A'
+      });
 
       // Ejecución del método
       await ApartmentController.updateApartment(req as Request, res as Response);
@@ -341,6 +347,10 @@ describe('ApartmentController', () => {
       req.body = {
         capacity: 'invalid-capacity' // Capacidad inválida
       };
+      vi.mocked(ApartmentModel.getApartmentById).mockResolvedValueOnce({
+        id: 1, name: 'Apartment', address: '123 Main St', capacity: 4, bathrooms: 2,
+        rooms: 2, price: 1000, description: 'Nice apartment', images: [], unitNumber: '1A'
+      });
 
       // Ejecución del método
       await ApartmentController.updateApartment(req as Request, res as Response);

--- a/src/__tests__/unit/controllers/car.test.ts
+++ b/src/__tests__/unit/controllers/car.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../../services/imageService.js', () => ({
   default: {
     uploadImages: vi.fn().mockResolvedValue({ success: true, urls: ['https://test-url.com/image.jpg'], errors: [] }),
     deleteImages: vi.fn().mockResolvedValue({ success: true, errors: [] }),
+    syncImages: vi.fn().mockResolvedValue({ images: undefined }),
     optimizeForContext: vi.fn().mockImplementation((images: string[]) => ({ images, responsiveImages: [] }))
   }
 }));
@@ -315,6 +316,7 @@ describe('CarController', () => {
         images: []
       };
 
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
       vi.mocked(validatePartialCar).mockReturnValueOnce({ success: true, data: {} });
       vi.mocked(CarModel.updateCar).mockResolvedValueOnce(updatedCar);
 
@@ -333,6 +335,7 @@ describe('CarController', () => {
       req.body = {
         price: 'invalid'
       };
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
 
       // Ejecución
       await CarController.updateCar(req as Request, res as Response);
@@ -348,6 +351,7 @@ describe('CarController', () => {
       req.body = {
         brand: '', // Inválido para el esquema
       };
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
 
       vi.mocked(validatePartialCar).mockReturnValueOnce({
         success: false,
@@ -380,8 +384,12 @@ describe('CarController', () => {
         { buffer: Buffer.from('test') } as Express.Multer.File
       ];
 
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
       vi.mocked(validatePartialCar).mockReturnValueOnce({ success: true, data: {} });
-      
+
+      const { default: ImageService } = await import('../../../services/imageService.js');
+      vi.mocked(ImageService.syncImages).mockResolvedValueOnce({ images: ['https://test-url.com/image.jpg'] });
+
       const updatedCar = {
         id: 1,
         brand: 'BMW',
@@ -390,7 +398,7 @@ describe('CarController', () => {
         price: 150,
         images: ['https://test-url.com/image.jpg']
       };
-      
+
       vi.mocked(CarModel.updateCar).mockResolvedValueOnce(updatedCar);
 
       // Ejecución
@@ -407,7 +415,8 @@ describe('CarController', () => {
         brand: 'BMW',
         model: 'X7',
       };
-      
+
+      vi.mocked(CarModel.getCarById).mockResolvedValueOnce({ id: 1, brand: 'BMW', model: 'X5', price: 150, images: [] });
       vi.mocked(validatePartialCar).mockReturnValueOnce({ success: true, data: {} });
       vi.mocked(CarModel.updateCar).mockRejectedValueOnce(new Error('Database error'));
 

--- a/src/controllers/apartment.ts
+++ b/src/controllers/apartment.ts
@@ -122,6 +122,13 @@ class ApartmentController {
     static async updateApartment(req: Request, res: Response): Promise<void> {
         try {
             const { id } = req.params
+
+            const existingApartment = await ApartmentModel.getApartmentById(Number(id))
+            if (!existingApartment) {
+                notFound(res, 'Apartment not found')
+                return
+            }
+
             const apartmentData: UpdateApartmentDTO = {}
 
             const updatableFields = ['name', 'unitNumber', 'description', 'address', 'capacity', 'bathrooms', 'rooms', 'price'];
@@ -163,17 +170,20 @@ class ApartmentController {
                 return
             }
 
-            if (req.files && Array.isArray(req.files) && req.files.length > 0) {
-                const uploadResult = await ImageService.uploadImages(req.files, {
-                    entityType: 'apartments'
-                });
+            const syncResult = await ImageService.syncImages({
+                currentImages: existingApartment.images || [],
+                existingImagesRaw: req.body.existingImages,
+                files: Array.isArray(req.files) ? req.files : undefined,
+                entityType: 'apartments'
+            });
 
-                if (!uploadResult.success) {
-                    badRequest(res, 'Error uploading images', uploadResult.errors);
-                    return;
-                }
+            if (syncResult.errors) {
+                badRequest(res, 'Error uploading images', syncResult.errors);
+                return;
+            }
 
-                apartmentData.images = uploadResult.urls;
+            if (syncResult.images !== undefined) {
+                apartmentData.images = syncResult.images;
             }
 
             const updatedApartment = await ApartmentModel.updateApartment(Number(id), apartmentData)

--- a/src/controllers/car.ts
+++ b/src/controllers/car.ts
@@ -128,6 +128,12 @@ class CarController {
         try {
             const { id } = req.params
 
+            const existingCar = await CarModel.getCarById(Number(id))
+            if (!existingCar) {
+                notFound(res, 'Car not found')
+                return
+            }
+
             const carData: UpdateCarsDTO = {
                 brand: req.body.brand,
                 model: req.body.model,
@@ -163,17 +169,20 @@ class CarController {
                 return
             }
 
-            if (req.files && Array.isArray(req.files) && req.files.length > 0) {
-                const uploadResult = await ImageService.uploadImages(req.files, {
-                    entityType: 'cars'
-                });
+            const syncResult = await ImageService.syncImages({
+                currentImages: existingCar.images || [],
+                existingImagesRaw: req.body.existingImages,
+                files: Array.isArray(req.files) ? req.files : undefined,
+                entityType: 'cars'
+            });
 
-                if (!uploadResult.success) {
-                    badRequest(res, 'Error uploading images', uploadResult.errors);
-                    return;
-                }
+            if (syncResult.errors) {
+                badRequest(res, 'Error uploading images', syncResult.errors);
+                return;
+            }
 
-                carData.images = uploadResult.urls;
+            if (syncResult.images !== undefined) {
+                carData.images = syncResult.images;
             }
 
             const updatedCar = await CarModel.updateCar(parseInt(id), carData);

--- a/src/controllers/villa.ts
+++ b/src/controllers/villa.ts
@@ -121,24 +121,20 @@ class VillaController {
             }
             const villaData: any = { ...validationResult.data };
 
-            if (req.files) {
-                const files = Array.isArray(req.files) ? req.files : Object.values(req.files).flat();
-                if (files.length > 0) {
-                    const uploadResult = await ImageService.uploadImages(files, {
-                        entityType: 'villas'
-                    });
+            const syncResult = await ImageService.syncImages({
+                currentImages: existingVilla.images || [],
+                existingImagesRaw: req.body.existingImages,
+                files: Array.isArray(req.files) ? req.files : (req.files ? Object.values(req.files).flat() : undefined),
+                entityType: 'villas'
+            });
 
-                    if (!uploadResult.success) {
-                        badRequest(res, 'Error uploading images', uploadResult.errors);
-                        return;
-                    }
+            if (syncResult.errors) {
+                badRequest(res, 'Error uploading images', syncResult.errors);
+                return;
+            }
 
-                    if (existingVilla && existingVilla.images) {
-                        villaData.images = [...existingVilla.images, ...uploadResult.urls];
-                    } else {
-                        villaData.images = uploadResult.urls;
-                    }
-                }
+            if (syncResult.images !== undefined) {
+                villaData.images = syncResult.images;
             }
 
             const updatedVilla = await VillaModel.updateVilla(id, villaData);

--- a/src/controllers/yacht.ts
+++ b/src/controllers/yacht.ts
@@ -115,21 +115,20 @@ class YachtController {
             }
             const yachtData: any = { ...validationResult.data };
 
-            if (req.files && Array.isArray(req.files) && req.files.length > 0) {
-                const uploadResult = await ImageService.uploadImages(req.files, {
-                    entityType: 'yachts'
-                });
+            const syncResult = await ImageService.syncImages({
+                currentImages: existingYacht.images || [],
+                existingImagesRaw: req.body.existingImages,
+                files: Array.isArray(req.files) ? req.files : undefined,
+                entityType: 'yachts'
+            });
 
-                if (!uploadResult.success) {
-                    badRequest(res, 'Error uploading images', uploadResult.errors);
-                    return;
-                }
+            if (syncResult.errors) {
+                badRequest(res, 'Error uploading images', syncResult.errors);
+                return;
+            }
 
-                if (existingYacht && existingYacht.images) {
-                    yachtData.images = [...existingYacht.images, ...uploadResult.urls];
-                } else {
-                    yachtData.images = uploadResult.urls;
-                }
+            if (syncResult.images !== undefined) {
+                yachtData.images = syncResult.images;
             }
 
             const updatedYacht = await YachtModel.updateYacht(id, yachtData);

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -27,6 +27,22 @@ export interface UploadOptions {
     publicIdPrefix?: string;
 }
 
+export interface SyncImagesOptions {
+    /** Imágenes actualmente guardadas en la entidad (antes del update) */
+    currentImages: string[];
+    /** req.body.existingImages tal cual llega (JSON string con el array final de URLs a conservar, o undefined si el cliente no gestiona imágenes) */
+    existingImagesRaw: unknown;
+    /** Archivos nuevos subidos en este request (req.files) */
+    files?: Express.Multer.File[];
+    entityType: keyof typeof IMAGE_CONFIGS;
+}
+
+export interface SyncImagesResult {
+    /** Array final a persistir. undefined si no hay que tocar el campo images */
+    images?: string[];
+    errors?: string[];
+}
+
 /**
  * Servicio centralizado para el manejo de imágenes con Cloudinary
  */
@@ -150,6 +166,58 @@ class ImageService {
                 errors: [`Error interno del servidor: ${error instanceof Error ? error.message : 'Error desconocido'}`]
             };
         }
+    }
+
+    /**
+     * Resuelve el array final de imágenes para un update: combina las imágenes
+     * existentes que el cliente decidió conservar (existingImagesRaw, en el orden
+     * que envía) con las nuevas subidas (files), y borra de Cloudinary las que
+     * quedaron afuera. Devuelve `images: undefined` cuando el cliente no mandó
+     * existingImages ni archivos nuevos, para no tocar el campo en ese caso.
+     */
+    static async syncImages(options: SyncImagesOptions): Promise<SyncImagesResult> {
+        const { currentImages, existingImagesRaw, files, entityType } = options;
+
+        let keptImages: string[] | undefined;
+        if (existingImagesRaw !== undefined) {
+            try {
+                const parsed = typeof existingImagesRaw === 'string'
+                    ? JSON.parse(existingImagesRaw)
+                    : existingImagesRaw;
+                keptImages = Array.isArray(parsed)
+                    ? parsed.filter((url: any): url is string => typeof url === 'string')
+                    : [];
+            } catch {
+                return { errors: ['El valor de existingImages no es un JSON válido'] };
+            }
+        }
+
+        let newUrls: string[] = [];
+        if (files && files.length > 0) {
+            const uploadResult = await this.uploadImages(files, { entityType });
+            if (!uploadResult.success) {
+                return { errors: uploadResult.errors };
+            }
+            newUrls = uploadResult.urls;
+        }
+
+        if (keptImages === undefined && newUrls.length === 0) {
+            return {};
+        }
+
+        const finalImages = [...(keptImages ?? currentImages), ...newUrls];
+
+        if (keptImages !== undefined) {
+            const removedImages = currentImages.filter(url => !keptImages!.includes(url));
+            if (removedImages.length > 0) {
+                const deleteResult = await this.deleteImages(removedImages, entityType);
+                if (!deleteResult.success && deleteResult.errors.length > 0) {
+                    console.warn(`Algunas imágenes de ${entityType} no pudieron eliminarse de Cloudinary:`, deleteResult.errors);
+                }
+            }
+        }
+
+        return { images: finalImages };
     }
 
     /**


### PR DESCRIPTION
## Summary
- Los updates de apartments/cars/yachts/villas sólo tocaban el campo `images` cuando llegaban archivos nuevos, y en ese caso lo reemplazaban entero en vez de mergear con lo existente. Borrar una imagen en el modal y guardar sin subir una nueva no persistía nada, y subir una imagen nueva pisaba las anteriores en apartments/cars.
- Nunca se borraba el asset de Cloudinary al sacar una imagen desde un update (sólo al borrar la entidad completa).
- Se agrega `ImageService.syncImages`: combina las imágenes existentes que el front decide conservar (`existingImages`, JSON del array final en el orden deseado) con las nuevas subidas, y borra de Cloudinary las que quedan afuera.
- Los 4 controllers ahora fetchean la entidad antes de actualizar (para poder diffear qué se sacó) y usan este método en vez de tocar `images` a mano.

## Test plan
- [x] `npx tsc --noEmit` sin errores
- [x] Suite completa de tests (`vitest run`): 405 passed, 5 todo — los únicos 2 fallos son preexistentes en `admin-routes.test.ts` (requieren DB real, no relacionados con este cambio)
- [x] Pendiente: prueba manual del usuario en el ambiente real (crear entidad de prueba, subir imagen, borrarla, confirmar que desaparece de Cloudinary, borrar la entidad)

Requiere el PR compañero en `MiamiGetAwayFront` (rama `development`) que ajusta el contrato de `existingImages` a JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)